### PR TITLE
Add minimap showing player position, walls, and enemies

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -298,6 +298,11 @@ class GameEngine {
                     this.hud.toggleWeaponSprite();
                     console.log('Weapon Sprite:', this.hud.showWeaponSprite ? 'ON' : 'OFF');
                     break;
+
+                case 'm':
+                    this.hud.toggleMinimap();
+                    console.log('Minimap:', this.hud.showMinimap ? 'ON' : 'OFF');
+                    break;
             }
         });
     }

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -22,6 +22,7 @@ class HUD {
         this.showDebugInfo = false;
         this.showCrosshair = true;
         this.showWeaponSprite = true;
+        this.showMinimap = true;
         
         // Animation
         this.lastDamageTime = 0;
@@ -96,6 +97,11 @@ class HUD {
 
             // Render XP bar and level
             this.renderProgressionHUD(player);
+
+            // Render minimap
+            if (this.showMinimap && gameEngine && gameEngine.map) {
+                this.renderMinimap(player, gameEngine);
+            }
 
             // Render floating damage numbers and impact effects
             this.renderDamageNumbers(player, gameEngine);
@@ -771,7 +777,87 @@ class HUD {
         }
     }
     
+    renderMinimap(player, gameEngine) {
+        const map = gameEngine.map;
+        const size = 150;
+        const padding = 10;
+        const mapX = this.canvas.width - size - padding;
+        const mapY = padding;
+
+        // Semi-transparent background
+        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+        this.ctx.fillRect(mapX, mapY, size, size);
+        this.ctx.strokeStyle = 'rgba(255, 255, 255, 0.4)';
+        this.ctx.strokeRect(mapX, mapY, size, size);
+
+        const cellW = size / map.width;
+        const cellH = size / map.height;
+
+        // Draw walls
+        for (let gy = 0; gy < map.height; gy++) {
+            for (let gx = 0; gx < map.width; gx++) {
+                if (map.grid[gy][gx] > 0) {
+                    const wallType = map.grid[gy][gx];
+                    switch (wallType) {
+                        case 1: this.ctx.fillStyle = '#555555'; break;
+                        case 2: this.ctx.fillStyle = '#884444'; break;
+                        case 3: this.ctx.fillStyle = '#448888'; break;
+                        case 4: this.ctx.fillStyle = '#446688'; break;
+                        case 5: this.ctx.fillStyle = '#888866'; break;
+                        case 6: this.ctx.fillStyle = '#666644'; break;
+                        case 9: this.ctx.fillStyle = '#886600'; break;
+                        default: this.ctx.fillStyle = '#444444'; break;
+                    }
+                    this.ctx.fillRect(
+                        mapX + gx * cellW,
+                        mapY + gy * cellH,
+                        Math.ceil(cellW),
+                        Math.ceil(cellH)
+                    );
+                }
+            }
+        }
+
+        // Draw enemies
+        const enemies = map.enemies;
+        for (const enemy of enemies) {
+            if (!enemy.active) continue;
+            const ex = mapX + (enemy.x / map.tileSize) * cellW;
+            const ey = mapY + (enemy.y / map.tileSize) * cellH;
+            this.ctx.fillStyle = enemy.type === 'boss' ? '#FFD700' : '#FF4444';
+            this.ctx.beginPath();
+            this.ctx.arc(ex, ey, Math.max(cellW * 0.6, 2), 0, Math.PI * 2);
+            this.ctx.fill();
+        }
+
+        // Draw player position and facing direction
+        const px = mapX + (player.x / map.tileSize) * cellW;
+        const py = mapY + (player.y / map.tileSize) * cellH;
+
+        // Player direction line
+        const dirLen = 8;
+        this.ctx.strokeStyle = '#00FF00';
+        this.ctx.lineWidth = 2;
+        this.ctx.beginPath();
+        this.ctx.moveTo(px, py);
+        this.ctx.lineTo(px + Math.cos(player.angle) * dirLen, py + Math.sin(player.angle) * dirLen);
+        this.ctx.stroke();
+
+        // Player dot
+        this.ctx.fillStyle = '#00FF00';
+        this.ctx.beginPath();
+        this.ctx.arc(px, py, 3, 0, Math.PI * 2);
+        this.ctx.fill();
+
+        // Reset line width
+        this.ctx.lineWidth = 1;
+    }
+
     // Toggle functions
+    toggleMinimap() {
+        this.showMinimap = !this.showMinimap;
+    }
+
     toggleFPS() {
         this.showFPS = !this.showFPS;
     }

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -594,6 +594,7 @@ const TIER_2_TESTS = [
   { id: 'T2-18', name: 'Project structure complete', fn: T2_18_projectStructure }, // issue: #30
   { id: 'T2-19', name: 'No Game loaded popup on start', fn: T2_19_noGameLoadedPopup }, // issue: #31
   { id: 'T2-20', name: 'Multi-room reactor map', fn: T2_20_multiRoomMap }, // issue: #33
+  { id: 'T2-21', name: 'Minimap system', fn: T2_21_minimapSystem }, // issue: #34
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -1588,6 +1589,65 @@ async function T2_20_multiRoomMap(page, result) {
   } else {
     result.status = 'fail';
     result.note = `Map checks: expanded=${mapData.isExpanded}, wallTypes=${mapData.wallTypeCount}, quadrants=${mapData.quadrantsCovered}, pickups=${mapData.hasPickups}`;
+  }
+}
+
+async function T2_21_minimapSystem(page, result) {
+  // T2-21: Minimap renders with player and enemies (issue: #34)
+  // Pass condition: Minimap system exists, renders, and can be toggled with M key
+  await page.waitForTimeout(1000);
+
+  const minimapData = await page.evaluate(() => {
+    if (!window.game || !window.game.hud) {
+      return { exists: false, reason: 'HUD not found' };
+    }
+
+    const hud = window.game.hud;
+
+    return {
+      exists: true,
+      hasShowMinimap: typeof hud.showMinimap === 'boolean',
+      hasRenderMinimap: typeof hud.renderMinimap === 'function',
+      hasToggleMinimap: typeof hud.toggleMinimap === 'function',
+      initialState: hud.showMinimap
+    };
+  });
+
+  if (!minimapData.exists) {
+    result.status = 'fail';
+    result.note = minimapData.reason;
+    return;
+  }
+
+  // Test M key toggle
+  const initialState = minimapData.initialState;
+
+  await page.keyboard.press('m');
+  await page.waitForTimeout(200);
+
+  const toggledState = await page.evaluate(() => window.game.hud.showMinimap);
+
+  await page.keyboard.press('m');
+  await page.waitForTimeout(200);
+
+  const restoredState = await page.evaluate(() => window.game.hud.showMinimap);
+
+  const checks = [
+    ['showMinimap property', minimapData.hasShowMinimap],
+    ['renderMinimap method', minimapData.hasRenderMinimap],
+    ['toggleMinimap method', minimapData.hasToggleMinimap],
+    ['M key toggles off', toggledState !== initialState],
+    ['M key toggles back on', restoredState === initialState]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = 'Minimap system functional with M key toggle';
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds a minimap overlay toggled with the M key
- Shows player position/direction, wall layout, and enemy positions
- Minimap renders in the top-right corner of the HUD

## Test plan
- [x] T2-21: Minimap system test passes
- [x] All 30 existing tests pass

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)