### PR TITLE
#38 Add melee punch attack as backup weapon

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -405,6 +405,50 @@ class SoundEngine {
         }
     }
 
+    // Melee punch sound
+    playPunch() {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Low thud with noise burst
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(100, now);
+        osc.frequency.exponentialRampToValueAtTime(40, now + 0.12);
+
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.7, now + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.15);
+
+        osc.start(now);
+        osc.stop(now + 0.15);
+
+        // Impact noise burst
+        const noiseBuffer = this.createNoiseBuffer(0.06);
+        const noiseSource = this.audioContext.createBufferSource();
+        const noiseGain = this.audioContext.createGain();
+        const filter = this.audioContext.createBiquadFilter();
+
+        noiseSource.buffer = noiseBuffer;
+        noiseSource.connect(filter);
+        filter.connect(noiseGain);
+        noiseGain.connect(this.masterGain);
+
+        filter.type = 'lowpass';
+        filter.frequency.setValueAtTime(400, now);
+
+        noiseGain.gain.setValueAtTime(0, now);
+        noiseGain.gain.linearRampToValueAtTime(this.sfxVolume * 0.5, now + 0.005);
+        noiseGain.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
+
+        noiseSource.start(now);
+        noiseSource.stop(now + 0.08);
+    }
+
     // Level complete victory fanfare
     playLevelComplete() {
         if (!this.isInitialized) return;

--- a/js/engine/input.js
+++ b/js/engine/input.js
@@ -49,6 +49,7 @@ class InputManager {
             
             // Weapon/interaction
             'KeyX': 'fire',
+            'KeyV': 'punch',
             'KeyE': 'use',
             'KeyR': 'reload',
             'KeyQ': 'weapon1',
@@ -306,6 +307,10 @@ class InputManager {
     
     isShooting() {
         return this.mouse.leftButton || this.isKeyDown('fire');
+    }
+
+    isPunching() {
+        return this.isKeyPressed('punch');
     }
     
     // Debug

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -60,7 +60,13 @@ class Player {
 
         // Weapon system
         this.weaponManager = new WeaponManager();
-        
+
+        // Melee punch system
+        this.punchDamage = 30;
+        this.punchRange = 40;
+        this.punchCooldown = 400; // ms
+        this.lastPunchTime = 0;
+
         // Power-up effects
         this.speedBoostEndTime = 0;
         this.damageBoostEndTime = 0;
@@ -186,12 +192,22 @@ class Player {
         if (inputManager.isUsingItem()) {
             this.useItem();
         }
-        
-        // Shooting
-        if (inputManager.isShooting()) {
-            this.shoot(map);
+
+        // Punching (V key)
+        if (inputManager.isPunching()) {
+            this.punch(map);
         }
-        
+
+        // Shooting — auto-punch if all ammo depleted
+        if (inputManager.isShooting()) {
+            const weapon = this.weaponManager.getCurrentWeapon();
+            if (weapon.ammo <= 0 && weapon.maxAmmo <= 0 && !weapon.isReloading) {
+                this.punch(map);
+            } else {
+                this.shoot(map);
+            }
+        }
+
         // Reload
         if (inputManager.isKeyPressed('reload')) {
             this.reload();
@@ -374,6 +390,84 @@ class Player {
         }
     }
     
+    punch(map) {
+        const now = Date.now();
+        if (now - this.lastPunchTime < this.punchCooldown) return;
+        this.lastPunchTime = now;
+
+        // Track shot for stats
+        if (this.stats) this.stats.shotsFired++;
+
+        // Play punch sound
+        if (window.soundEngine && window.soundEngine.isInitialized) {
+            window.soundEngine.playPunch();
+        }
+
+        // Screen shake + forward lunge effect
+        if (window.game && window.game.hud) {
+            window.game.hud.triggerScreenShake(4);
+        }
+
+        // Check for enemies within melee range
+        let closestEnemy = null;
+        let closestDist = this.punchRange;
+
+        if (map && map.enemies) {
+            for (const enemy of map.enemies) {
+                if (!enemy.active) continue;
+                const dx = enemy.x - this.x;
+                const dy = enemy.y - this.y;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+
+                // Check if enemy is roughly in front of the player (within 90 degrees)
+                const angleToEnemy = Math.atan2(dy, dx);
+                let angleDiff = angleToEnemy - this.angle;
+                while (angleDiff > Math.PI) angleDiff -= Math.PI * 2;
+                while (angleDiff < -Math.PI) angleDiff += Math.PI * 2;
+
+                if (dist < closestDist && Math.abs(angleDiff) < Math.PI / 2) {
+                    closestEnemy = enemy;
+                    closestDist = dist;
+                }
+            }
+        }
+
+        if (closestEnemy) {
+            let damage = this.punchDamage;
+
+            // Apply damage boost
+            if (this.hasDamageBoost && this.hasDamageBoost()) {
+                damage = Math.round(damage * 1.5);
+            }
+            if (this.levelBonuses) {
+                damage = Math.round(damage * this.levelBonuses.damageMultiplier);
+            }
+
+            if (this.stats) {
+                this.stats.shotsHit++;
+                this.stats.damageDealt += damage;
+            }
+
+            const wasAlive = closestEnemy.active;
+            closestEnemy.takeDamage(damage);
+
+            if (wasAlive && !closestEnemy.active) {
+                if (this.stats) this.stats.enemiesKilled++;
+                const xpTable = { imp: 15, guard: 20, soldier: 30, demon: 40, berserker: 35, spitter: 25, shield_guard: 45, boss: 200 };
+                if (this.addXP) this.addXP(xpTable[closestEnemy.type] || 20);
+            }
+
+            // Visual feedback
+            closestEnemy.hitFlashTime = Date.now();
+            if (window.game && window.game.hud) {
+                window.game.hud.emitBloodParticles(closestEnemy.x, closestEnemy.y, wasAlive && !closestEnemy.active ? 12 : 5);
+                window.game.hud.addDamageNumber(closestEnemy.x, closestEnemy.y, damage, false);
+            }
+
+            console.log(`Punch hit ${closestEnemy.type} for ${damage} damage!`);
+        }
+    }
+
     reload() {
         const success = this.weaponManager.reload();
         if (success) {

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -602,6 +602,7 @@ const TIER_2_TESTS = [
   { id: 'T2-21', name: 'Minimap system', fn: T2_21_minimapSystem }, // issue: #34
   { id: 'T2-22', name: 'Difficulty selection system', fn: T2_22_difficultySelection }, // issue: #35
   { id: 'T2-23', name: 'Level completion screen', fn: T2_23_levelCompletionScreen }, // issue: #36
+  { id: 'T2-24', name: 'Melee punch attack', fn: T2_24_meleePunch }, // issue: #38
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -1793,6 +1794,57 @@ async function T2_23_levelCompletionScreen(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Level completion system: ${completionData.totalEnemies} enemies tracked, stats + restart + victory sound`;
+  }
+}
+
+async function T2_24_meleePunch(page, result) {
+  // T2-24: Melee punch attack (issue: #38)
+  // Pass condition: Punch system exists with correct damage, range, cooldown, sound
+  await page.waitForTimeout(1000);
+
+  const punchData = await page.evaluate(() => {
+    if (!window.game || !window.game.player) {
+      return { exists: false, reason: 'Player not found' };
+    }
+
+    const p = window.game.player;
+
+    return {
+      exists: true,
+      hasPunchMethod: typeof p.punch === 'function',
+      punchDamage: p.punchDamage,
+      punchRange: p.punchRange,
+      punchCooldown: p.punchCooldown,
+      hasPunchSound: window.soundEngine && typeof window.soundEngine.playPunch === 'function',
+      hasVKey: window.game.inputManager && window.game.inputManager.keyMap['KeyV'] === 'punch',
+      hasIsPunching: typeof window.game.inputManager.isPunching === 'function'
+    };
+  });
+
+  if (!punchData.exists) {
+    result.status = 'fail';
+    result.note = punchData.reason;
+    return;
+  }
+
+  const checks = [
+    ['punch method', punchData.hasPunchMethod],
+    ['30 damage', punchData.punchDamage === 30],
+    ['40 range', punchData.punchRange === 40],
+    ['400ms cooldown', punchData.punchCooldown === 400],
+    ['punch sound', punchData.hasPunchSound],
+    ['V key binding', punchData.hasVKey],
+    ['isPunching query', punchData.hasIsPunching]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Punch: ${punchData.punchDamage}dmg, ${punchData.punchRange} range, ${punchData.punchCooldown}ms cooldown, V key + sound`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds melee punch on V key: 30 damage, 40 range, 0.4s cooldown
- Auto-punches when trying to fire with no ammo left
- Hits closest enemy in a 90-degree forward cone
- Procedural punch sound + screen shake visual feedback
- Tracks punch stats (shots fired/hit, damage, kills, XP)
- Adds playtester test T2-24

## Test plan
- [x] All 33 playtester tests pass (0 failures)
- [x] V key triggers punch attack
- [x] Punch damages enemies at close range
- [x] Punch cooldown prevents spam
- [x] Auto-punch works when ammo depleted

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)