### PR TITLE
#45 Add weapon pickup items scattered across the map

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -67,6 +67,7 @@ class GameEngine {
         
         // Initialize pickup system
         this.pickupManager = new PickupManager();
+        this.pickupManager.spawnWeaponPickups(this.map);
         this.pickupManager.spawnRandomPickups(this.map, 6);
         console.log('Pickup system initialized');
         
@@ -211,6 +212,7 @@ class GameEngine {
 
         // Re-initialize pickups
         this.pickupManager = new PickupManager();
+        this.pickupManager.spawnWeaponPickups(this.map);
         this.pickupManager.spawnRandomPickups(this.map, 6);
 
         // Re-apply difficulty

--- a/js/entities/pickup.js
+++ b/js/entities/pickup.js
@@ -121,6 +121,34 @@ class Pickup {
                 maxValue: 0,
                 sound: 'powerup',
                 message: 'Health Regen!'
+            },
+            weapon_shotgun: {
+                value: 0,
+                color: '#FF8800',
+                maxValue: 0,
+                sound: 'weapon',
+                message: 'Shotgun Acquired!'
+            },
+            weapon_rifle: {
+                value: 0,
+                color: '#AA8800',
+                maxValue: 0,
+                sound: 'weapon',
+                message: 'Rifle Acquired!'
+            },
+            weapon_rocket: {
+                value: 0,
+                color: '#FF4444',
+                maxValue: 0,
+                sound: 'weapon',
+                message: 'Rocket Launcher Acquired!'
+            },
+            weapon_chaingun: {
+                value: 0,
+                color: '#CCCC00',
+                maxValue: 0,
+                sound: 'weapon',
+                message: 'Chaingun Acquired!'
             }
         };
         
@@ -137,8 +165,8 @@ class Pickup {
         // Animate bobbing
         this.bobOffset += this.bobSpeed * deltaTime;
         
-        // Animate rotation for power-ups
-        if (this.type.includes('boost')) {
+        // Animate rotation for power-ups and weapon pickups
+        if (this.type.includes('boost') || this.type.startsWith('weapon_')) {
             this.rotation += this.rotationSpeed * deltaTime;
         }
         
@@ -239,6 +267,19 @@ class Pickup {
                 player.applyHealthRegen(props.value);
                 canCollect = true;
                 break;
+
+            case 'weapon_shotgun':
+            case 'weapon_rifle':
+            case 'weapon_rocket':
+            case 'weapon_chaingun': {
+                const weaponName = this.type.replace('weapon_', '');
+                if (!player.weaponManager.isUnlocked(weaponName)) {
+                    player.weaponManager.unlockWeapon(weaponName);
+                    player.weaponManager.switchWeapon(weaponName);
+                    canCollect = true;
+                }
+                break;
+            }
         }
         
         if (canCollect) {
@@ -269,6 +310,8 @@ class Pickup {
             this.playArmorSound();
         } else if (soundType === 'powerup') {
             this.playPowerupSound();
+        } else if (soundType === 'weapon') {
+            this.playWeaponPickupSound();
         }
     }
     
@@ -364,6 +407,31 @@ class Pickup {
         });
     }
     
+    playWeaponPickupSound() {
+        const now = window.soundEngine.audioContext.currentTime;
+
+        // Dramatic ascending chord for weapon pickup
+        const frequencies = [330, 415, 523, 660]; // E major chord ascending
+        frequencies.forEach((freq, i) => {
+            const oscillator = window.soundEngine.audioContext.createOscillator();
+            const gainNode = window.soundEngine.audioContext.createGain();
+
+            oscillator.connect(gainNode);
+            gainNode.connect(window.soundEngine.masterGain);
+
+            oscillator.type = 'sawtooth';
+            oscillator.frequency.setValueAtTime(freq, now + i * 0.06);
+
+            const startDelay = i * 0.06;
+            gainNode.gain.setValueAtTime(0, now + startDelay);
+            gainNode.gain.linearRampToValueAtTime(0.2, now + startDelay + 0.05);
+            gainNode.gain.exponentialRampToValueAtTime(0.001, now + startDelay + 0.6);
+
+            oscillator.start(now + startDelay);
+            oscillator.stop(now + startDelay + 0.6);
+        });
+    }
+
     showCollectionMessage(message) {
         // This would integrate with a message system or HUD
         // For now, just console log
@@ -415,6 +483,23 @@ class PickupManager {
         this.pickups = [];
     }
     
+    // Spawn weapon pickups at fixed map locations
+    spawnWeaponPickups(map) {
+        const tileSize = map.tileSize;
+        const weaponLocations = [
+            { type: 'weapon_shotgun',  x: 5.5  * tileSize, y: 5.5  * tileSize }, // Control Room area
+            { type: 'weapon_rifle',    x: 1.5  * tileSize, y: 12.5 * tileSize }, // Cooling tunnel west
+            { type: 'weapon_rocket',   x: 12.5 * tileSize, y: 14.5 * tileSize }, // Reactor Core south
+            { type: 'weapon_chaingun', x: 20.5 * tileSize, y: 11.5 * tileSize }  // Containment Wing east
+        ];
+
+        for (const loc of weaponLocations) {
+            if (!map.isWallAtPosition(loc.x, loc.y)) {
+                this.addPickup(loc.x, loc.y, loc.type);
+            }
+        }
+    }
+
     // Spawn random pickups around the map
     spawnRandomPickups(map, count = 5) {
         const pickupTypes = ['health', 'ammo_pistol', 'ammo_shotgun', 'ammo_rifle', 'ammo_rocket', 'ammo_chaingun', 'armor'];

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -855,6 +855,20 @@ class HUD {
             }
         }
 
+        // Draw weapon pickups
+        if (gameEngine.pickupManager) {
+            const pickups = gameEngine.pickupManager.getActivePickups();
+            for (const pickup of pickups) {
+                if (!pickup.type.startsWith('weapon_')) continue;
+                const wx = mapX + (pickup.x / map.tileSize) * cellW;
+                const wy = mapY + (pickup.y / map.tileSize) * cellH;
+                this.ctx.fillStyle = pickup.properties.color;
+                this.ctx.beginPath();
+                this.ctx.arc(wx, wy, Math.max(cellW * 0.5, 2), 0, Math.PI * 2);
+                this.ctx.fill();
+            }
+        }
+
         // Draw enemies
         const enemies = map.enemies;
         for (const enemy of enemies) {

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -359,16 +359,32 @@ class WeaponManager {
             rocket: new Weapon('rocket'),
             chaingun: new Weapon('chaingun')
         };
-        
+
         this.currentWeapon = 'pistol';
+
+        // Only pistol is unlocked at start; others must be picked up
+        this.unlockedWeapons = new Set(['pistol']);
     }
-    
+
     getCurrentWeapon() {
         return this.weapons[this.currentWeapon];
     }
-    
-    switchWeapon(weaponType) {
+
+    isUnlocked(weaponType) {
+        return this.unlockedWeapons.has(weaponType);
+    }
+
+    unlockWeapon(weaponType) {
         if (this.weapons[weaponType]) {
+            this.unlockedWeapons.add(weaponType);
+            console.log(`Unlocked weapon: ${weaponType}`);
+            return true;
+        }
+        return false;
+    }
+
+    switchWeapon(weaponType) {
+        if (this.weapons[weaponType] && this.unlockedWeapons.has(weaponType)) {
             this.currentWeapon = weaponType;
             console.log(`Switched to ${weaponType}`);
             return true;

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -292,6 +292,11 @@ async function T2_03_weaponSwitching(page, result) {
     return;
   }
 
+  // Unlock shotgun so we can test switching
+  await page.evaluate(() => {
+    window.game.player.weaponManager.unlockWeapon('shotgun');
+  });
+
   // Try switching weapon
   await page.keyboard.press('2');
   await page.waitForTimeout(500);
@@ -299,6 +304,10 @@ async function T2_03_weaponSwitching(page, result) {
   const newWeapon = await page.evaluate(() => {
     return window.game.player.weaponManager.currentWeapon;
   });
+
+  // Restore back to pistol
+  await page.keyboard.press('1');
+  await page.waitForTimeout(200);
 
   if (initialWeapon === newWeapon) {
     result.status = 'fail';
@@ -604,6 +613,7 @@ const TIER_2_TESTS = [
   { id: 'T2-23', name: 'Level completion screen', fn: T2_23_levelCompletionScreen }, // issue: #36
   { id: 'T2-24', name: 'Melee punch attack', fn: T2_24_meleePunch }, // issue: #38
   { id: 'T2-25', name: 'Damage flash and low-health effects', fn: T2_25_damageFlashEffects }, // issue: #40
+  { id: 'T2-26', name: 'Weapon pickups on map', fn: T2_26_weaponPickups }, // issue: #45
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -829,6 +839,12 @@ async function T2_11_advancedWeapons(page, result) {
       damage: wm.weapons.chaingun.damage,
       fireRate: wm.weapons.chaingun.fireRate
     } : null;
+
+    // Unlock weapons for testing, then test switching
+    if (wm.unlockWeapon) {
+      wm.unlockWeapon('rocket');
+      wm.unlockWeapon('chaingun');
+    }
 
     // Test switching to rocket launcher
     let canSwitchRocket = false;
@@ -1915,6 +1931,82 @@ async function T2_25_damageFlashEffects(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Damage flash (${effectData.flashDuration}ms) + low-health vignette pulse at <25% HP`;
+  }
+}
+
+async function T2_26_weaponPickups(page, result) {
+  // T2-26: Weapon pickups scattered across the map (issue: #45)
+  // Pass condition: Player starts with pistol only, weapon pickups exist, collecting unlocks weapon
+  await page.waitForTimeout(1000);
+
+  const pickupData = await page.evaluate(() => {
+    if (!window.game || !window.game.player || !window.game.pickupManager) {
+      return { exists: false, reason: 'Game systems not found' };
+    }
+
+    const wm = window.game.player.weaponManager;
+    const pm = window.game.pickupManager;
+
+    // Check player starts with pistol only
+    const hasUnlockedWeapons = wm.unlockedWeapons instanceof Set;
+    const startsWithPistol = hasUnlockedWeapons && wm.unlockedWeapons.has('pistol');
+    const onlyPistolAtStart = hasUnlockedWeapons && wm.unlockedWeapons.size === 1;
+
+    // Check weapon pickups exist
+    const allPickups = pm.getActivePickups();
+    const weaponPickups = allPickups.filter(p => p.type.startsWith('weapon_'));
+    const weaponTypes = weaponPickups.map(p => p.type);
+
+    // Check unlock method
+    const hasUnlockMethod = typeof wm.unlockWeapon === 'function';
+    const hasIsUnlocked = typeof wm.isUnlocked === 'function';
+
+    // Test unlocking a weapon
+    let unlockWorks = false;
+    if (hasUnlockMethod && hasIsUnlocked) {
+      const wasShotgunLocked = !wm.isUnlocked('shotgun');
+      wm.unlockWeapon('shotgun');
+      unlockWorks = wm.isUnlocked('shotgun');
+      // Remove shotgun unlock for clean state (only if it was locked)
+      if (wasShotgunLocked) wm.unlockedWeapons.delete('shotgun');
+    }
+
+    return {
+      exists: true,
+      hasUnlockedWeapons,
+      startsWithPistol,
+      onlyPistolAtStart,
+      weaponPickupCount: weaponPickups.length,
+      weaponTypes,
+      hasUnlockMethod,
+      hasIsUnlocked,
+      unlockWorks
+    };
+  });
+
+  if (!pickupData.exists) {
+    result.status = 'fail';
+    result.note = pickupData.reason;
+    return;
+  }
+
+  const checks = [
+    ['unlockedWeapons tracking', pickupData.hasUnlockedWeapons],
+    ['starts with pistol', pickupData.startsWithPistol],
+    ['weapon pickups on map', pickupData.weaponPickupCount >= 4],
+    ['unlockWeapon method', pickupData.hasUnlockMethod],
+    ['isUnlocked method', pickupData.hasIsUnlocked],
+    ['unlock works', pickupData.unlockWorks]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Weapon pickups: ${pickupData.weaponPickupCount} on map [${pickupData.weaponTypes.join(', ')}], unlock system works`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Player now starts with pistol only; other weapons must be picked up from the map
- 4 weapon pickups (shotgun, rifle, rocket launcher, chaingun) placed at strategic map locations
- Weapon pickups have floating/rotating animation and distinctive ascending chord pickup sound
- Minimap shows weapon pickup locations as colored dots
- WeaponManager now tracks locked/unlocked weapons with `unlockWeapon()` / `isUnlocked()` API
- Existing tests updated for weapon lock system; new T2-26 test verifies pickup system

## Test plan
- [x] Player starts with pistol only (no other weapons switchable)
- [x] Walking over weapon pickup unlocks it and auto-switches
- [x] Weapon pickups visible on minimap as colored dots
- [x] All 35 tests pass (+ new T2-26)
- [x] Existing weapon switching tests (T2-03, T2-11) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)