### PR TITLE
#47 Add HUD kill feed showing recent kills and events

### DIFF
--- a/js/entities/pickup.js
+++ b/js/entities/pickup.js
@@ -291,7 +291,13 @@ class Pickup {
             
             // Show collection message
             this.showCollectionMessage(props.message);
-            
+
+            // Kill feed message for pickups
+            if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
+                const color = this.type.startsWith('weapon_') ? '#00FF00' : '#00CC00';
+                window.game.hud.addKillFeedMessage(props.message, color);
+            }
+
             console.log(`Player collected ${this.type}: ${props.message}`);
         }
     }

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -454,7 +454,14 @@ class Player {
             if (wasAlive && !closestEnemy.active) {
                 if (this.stats) this.stats.enemiesKilled++;
                 const xpTable = { imp: 15, guard: 20, soldier: 30, demon: 40, berserker: 35, spitter: 25, shield_guard: 45, boss: 200 };
-                if (this.addXP) this.addXP(xpTable[closestEnemy.type] || 20);
+                const xpReward = xpTable[closestEnemy.type] || 20;
+                if (this.addXP) this.addXP(xpReward);
+
+                // Kill feed message for punch kills
+                if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
+                    const typeName = (closestEnemy.type || 'enemy').charAt(0).toUpperCase() + (closestEnemy.type || 'enemy').slice(1);
+                    window.game.hud.addKillFeedMessage(`Punched ${typeName} +${xpReward} XP`, '#FF4444');
+                }
             }
 
             // Visual feedback
@@ -658,6 +665,11 @@ class Player {
         this.health = Math.min(this.health + 20, this.maxHealth); // Heal 20 on level up
         this.baseSpeed = 200 + this.levelBonuses.speedBonus;
         this.speed = this.baseSpeed;
+
+        // Kill feed message for level up
+        if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
+            window.game.hud.addKillFeedMessage(`LEVEL UP! Now Level ${this.level}`, '#FFD700');
+        }
 
         console.log(`Level up! Now level ${this.level}. Max HP: ${this.maxHealth}, DMG: ${(this.levelBonuses.damageMultiplier * 100).toFixed(0)}%`);
     }

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -42,6 +42,11 @@ class HUD {
         this.shakeIntensity = 0;
         this.shakeDecay = 0.9;
 
+        // Kill feed
+        this.killFeed = [];
+        this.killFeedMax = 4;
+        this.killFeedDuration = 3000; // 3 seconds
+
         console.log('HUD system initialized');
     }
     
@@ -102,6 +107,9 @@ class HUD {
             if (this.showMinimap && gameEngine && gameEngine.map) {
                 this.renderMinimap(player, gameEngine);
             }
+
+            // Render kill feed
+            this.renderKillFeed();
 
             // Render floating damage numbers and impact effects
             this.renderDamageNumbers(player, gameEngine);
@@ -711,6 +719,50 @@ class HUD {
         const kills = player.stats ? player.stats.enemiesKilled : 0;
         this.ctx.fillStyle = '#FF8888';
         this.ctx.fillText(`K:${kills}`, x + barWidth - 30, y + 10);
+    }
+
+    // Kill feed system
+    addKillFeedMessage(text, color = '#FF4444') {
+        this.killFeed.unshift({
+            text,
+            color,
+            time: Date.now()
+        });
+        // Keep only max messages
+        if (this.killFeed.length > this.killFeedMax * 2) {
+            this.killFeed.length = this.killFeedMax * 2;
+        }
+    }
+
+    renderKillFeed() {
+        const now = Date.now();
+        // Remove expired messages
+        this.killFeed = this.killFeed.filter(m => now - m.time < this.killFeedDuration);
+
+        const visible = this.killFeed.slice(0, this.killFeedMax);
+        if (visible.length === 0) return;
+
+        const x = this.canvas.width - 160;
+        const startY = 175; // Below minimap (which is 150+10 padding)
+
+        for (let i = 0; i < visible.length; i++) {
+            const msg = visible[i];
+            const age = now - msg.time;
+            const alpha = Math.max(0, 1 - (age / this.killFeedDuration));
+            const y = startY + i * 18;
+
+            // Background
+            this.ctx.fillStyle = `rgba(0, 0, 0, ${alpha * 0.5})`;
+            this.ctx.fillRect(x - 5, y - 11, 170, 16);
+
+            // Text
+            this.ctx.globalAlpha = alpha;
+            this.ctx.fillStyle = msg.color;
+            this.ctx.font = this.smallFont;
+            this.ctx.textAlign = 'right';
+            this.ctx.fillText(msg.text, this.canvas.width - 15, y);
+            this.ctx.globalAlpha = 1.0;
+        }
     }
 
     // Called when player takes damage

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -162,6 +162,14 @@ class Weapon {
                 // Grant XP based on enemy type
                 const xpReward = this.getKillXP(hit.enemy);
                 if (player.addXP) player.addXP(xpReward);
+
+                // Kill feed message
+                if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
+                    const typeName = (hit.enemy.type || 'enemy').charAt(0).toUpperCase() + (hit.enemy.type || 'enemy').slice(1);
+                    const prefix = isCritical ? 'CRITICAL! Killed' : 'Killed';
+                    const color = isCritical ? '#FFD700' : '#FF4444';
+                    window.game.hud.addKillFeedMessage(`${prefix} ${typeName} +${xpReward} XP`, color);
+                }
             }
 
             // Trigger enemy hit flash and blood particles

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -615,6 +615,7 @@ const TIER_2_TESTS = [
   { id: 'T2-25', name: 'Damage flash and low-health effects', fn: T2_25_damageFlashEffects }, // issue: #40
   { id: 'T2-26', name: 'Weapon pickups on map', fn: T2_26_weaponPickups }, // issue: #45
   { id: 'T2-27', name: 'Environmental hazards', fn: T2_27_environmentalHazards }, // issue: #46
+  { id: 'T2-28', name: 'Kill feed system', fn: T2_28_killFeed }, // issue: #47
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -1932,6 +1933,78 @@ async function T2_25_damageFlashEffects(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Damage flash (${effectData.flashDuration}ms) + low-health vignette pulse at <25% HP`;
+  }
+}
+
+async function T2_28_killFeed(page, result) {
+  // T2-28: Kill feed system (issue: #47)
+  // Pass condition: Kill feed renders in top-right, messages auto-fade, max 4 visible
+  await page.waitForTimeout(1000);
+
+  const feedData = await page.evaluate(() => {
+    if (!window.game || !window.game.hud) {
+      return { exists: false, reason: 'HUD not found' };
+    }
+
+    const hud = window.game.hud;
+
+    // Check kill feed system
+    const hasKillFeed = Array.isArray(hud.killFeed);
+    const hasAddMethod = typeof hud.addKillFeedMessage === 'function';
+    const hasRenderMethod = typeof hud.renderKillFeed === 'function';
+    const hasMax = typeof hud.killFeedMax === 'number';
+    const hasDuration = typeof hud.killFeedDuration === 'number';
+    const maxIs4 = hud.killFeedMax === 4;
+    const durationIs3000 = hud.killFeedDuration === 3000;
+
+    // Test adding messages
+    let addWorks = false;
+    if (hasAddMethod) {
+      const before = hud.killFeed.length;
+      hud.addKillFeedMessage('Killed Guard +20 XP', '#FF4444');
+      hud.addKillFeedMessage('CRITICAL! Killed Imp +30 XP', '#FFD700');
+      hud.addKillFeedMessage('Shotgun Acquired!', '#00FF00');
+      addWorks = hud.killFeed.length === before + 3;
+      // Clean up
+      hud.killFeed.splice(before);
+    }
+
+    return {
+      exists: true,
+      hasKillFeed,
+      hasAddMethod,
+      hasRenderMethod,
+      hasMax,
+      hasDuration,
+      maxIs4,
+      durationIs3000,
+      addWorks
+    };
+  });
+
+  if (!feedData.exists) {
+    result.status = 'fail';
+    result.note = feedData.reason;
+    return;
+  }
+
+  const checks = [
+    ['killFeed array', feedData.hasKillFeed],
+    ['addKillFeedMessage method', feedData.hasAddMethod],
+    ['renderKillFeed method', feedData.hasRenderMethod],
+    ['max 4 messages', feedData.maxIs4],
+    ['3s fade duration', feedData.durationIs3000],
+    ['adding messages works', feedData.addWorks]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Kill feed: max ${feedData.maxIs4 ? 4 : '?'} msgs, ${feedData.durationIs3000 ? '3s' : '?'} fade, color-coded`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Kill feed in top-right corner below minimap, max 4 messages visible
- Messages auto-fade after 3 seconds with alpha transition
- Color-coded: kills in red, critical kills in gold, pickups in green, level-ups in gold
- Punch kills show "Punched [type]" for distinct melee identification
- Triggered from weapon fire kills, melee punch kills, item/weapon pickups, and level-ups

## Test plan
- [x] Kill feed renders in top-right corner
- [x] Enemy kills display with XP amount
- [x] Critical kills highlighted differently (gold)
- [x] Messages auto-fade after 3 seconds
- [x] Max 4 messages shown simultaneously
- [x] All 37 tests pass (+ new T2-28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)