### PR TITLE
Add fullscreen support via F key

### DIFF
--- a/controls.html
+++ b/controls.html
@@ -150,6 +150,10 @@
                             <span class="control-desc">Release pointer lock</span>
                         </div>
                         <div class="control-row">
+                            <span class="control-key">F</span>
+                            <span class="control-desc">Toggle fullscreen mode</span>
+                        </div>
+                        <div class="control-row">
                             <span class="control-key">F1</span>
                             <span class="control-desc">Toggle debug overlay</span>
                         </div>

--- a/css/site.css
+++ b/css/site.css
@@ -321,6 +321,19 @@ a:hover {
     border-radius: 2px;
 }
 
+.game-wrapper:fullscreen {
+    background: #000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100vw;
+    height: 100vh;
+}
+
+.game-wrapper:fullscreen #gameCanvas {
+    border: none;
+}
+
 #ui {
     position: absolute;
     top: 10px;

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
                     <div>Angle: <span id="playerAngle">0</span>&deg;</div>
                 </div>
                 <div id="instructions">
-                    WASD: Move &nbsp;|&nbsp; Mouse: Look &nbsp;|&nbsp; Click to lock pointer &nbsp;|&nbsp; ESC: Release
+                    WASD: Move &nbsp;|&nbsp; Mouse: Look &nbsp;|&nbsp; Click to lock pointer &nbsp;|&nbsp; F: Fullscreen &nbsp;|&nbsp; ESC: Release
                 </div>
             </div>
         </div>

--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -140,6 +140,11 @@ class GameEngine {
         if (this.inputManager.isKeyPressed('menu')) {
             this.pause();
         }
+
+        // Handle fullscreen toggle
+        if (this.inputManager.isKeyPressed('fullscreen')) {
+            this.toggleFullscreen();
+        }
         
         // Player input handling
         this.player.handleInput(this.inputManager, this.deltaTime, this.map);
@@ -548,6 +553,17 @@ class GameEngine {
         this.currentState = newState;
     }
     
+    toggleFullscreen() {
+        const wrapper = this.canvas.parentElement;
+        if (!document.fullscreenElement) {
+            wrapper.requestFullscreen().catch(err => {
+                console.warn('Fullscreen request failed:', err);
+            });
+        } else {
+            document.exitFullscreen();
+        }
+    }
+
     // Event handling
     onResize(width, height) {
         this.canvas.width = width;

--- a/js/engine/input.js
+++ b/js/engine/input.js
@@ -63,7 +63,8 @@ class InputManager {
             'Escape': 'menu',
             'KeyM': 'map',
             'Tab': 'scores',
-            'F1': 'debug'
+            'F1': 'debug',
+            'KeyF': 'fullscreen'
         };
         
         // Bind event listeners

--- a/js/main.js
+++ b/js/main.js
@@ -221,6 +221,17 @@ function setupEventListeners() {
         }
     });
     
+    // Fullscreen change handling
+    document.addEventListener('fullscreenchange', function() {
+        const canvas = document.getElementById(CONFIG.canvas.id);
+        if (canvas) {
+            // Small delay to let the browser settle fullscreen dimensions
+            setTimeout(function() {
+                handleResize(canvas);
+            }, 100);
+        }
+    });
+
     // Error handling
     window.addEventListener('error', function(event) {
         console.error('Global error:', event.error);
@@ -244,31 +255,43 @@ function setupResizeHandling(canvas) {
 }
 
 function handleResize(canvas) {
+    const isFullscreen = !!document.fullscreenElement;
     const container = canvas.parentElement;
-    const maxWidth = container.clientWidth;
-    const maxHeight = container.clientHeight;
-    
+    const maxWidth = isFullscreen ? window.innerWidth : container.clientWidth;
+    const maxHeight = isFullscreen ? window.innerHeight : container.clientHeight;
+
     // Maintain aspect ratio
     const aspectRatio = CONFIG.canvas.defaultWidth / CONFIG.canvas.defaultHeight;
     let newWidth, newHeight;
-    
-    if (maxWidth / maxHeight > aspectRatio) {
-        newHeight = Math.min(maxHeight, CONFIG.canvas.defaultHeight);
-        newWidth = newHeight * aspectRatio;
+
+    if (isFullscreen) {
+        // In fullscreen, fill as much space as possible while keeping aspect ratio
+        if (maxWidth / maxHeight > aspectRatio) {
+            newHeight = maxHeight;
+            newWidth = newHeight * aspectRatio;
+        } else {
+            newWidth = maxWidth;
+            newHeight = newWidth / aspectRatio;
+        }
     } else {
-        newWidth = Math.min(maxWidth, CONFIG.canvas.defaultWidth);
-        newHeight = newWidth / aspectRatio;
+        if (maxWidth / maxHeight > aspectRatio) {
+            newHeight = Math.min(maxHeight, CONFIG.canvas.defaultHeight);
+            newWidth = newHeight * aspectRatio;
+        } else {
+            newWidth = Math.min(maxWidth, CONFIG.canvas.defaultWidth);
+            newHeight = newWidth / aspectRatio;
+        }
     }
-    
+
     // Update canvas size
     canvas.style.width = newWidth + 'px';
     canvas.style.height = newHeight + 'px';
-    
+
     // Update game engine
     if (game) {
         game.onResize(newWidth, newHeight);
     }
-    
+
     console.log(`Canvas resized to ${newWidth}x${newHeight}`);
 }
 

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -616,6 +616,7 @@ const TIER_2_TESTS = [
   { id: 'T2-26', name: 'Weapon pickups on map', fn: T2_26_weaponPickups }, // issue: #45
   { id: 'T2-27', name: 'Environmental hazards', fn: T2_27_environmentalHazards }, // issue: #46
   { id: 'T2-28', name: 'Kill feed system', fn: T2_28_killFeed }, // issue: #47
+  { id: 'T2-29', name: 'Fullscreen support', fn: T2_29_fullscreenSupport }, // issue: #48
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -2168,6 +2169,52 @@ async function T2_26_weaponPickups(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Weapon pickups: ${pickupData.weaponPickupCount} on map [${pickupData.weaponTypes.join(', ')}], unlock system works`;
+  }
+}
+
+async function T2_29_fullscreenSupport(page, result) {
+  // T2-29: Fullscreen support (issue: #48)
+  // Pass condition: Game engine has toggleFullscreen method, F key is mapped
+  await page.waitForTimeout(1000);
+
+  const fsData = await page.evaluate(() => {
+    if (!window.game) {
+      return { exists: false, reason: 'Game not found' };
+    }
+
+    const hasToggleMethod = typeof window.game.toggleFullscreen === 'function';
+    const hasKeyMapping = window.game.inputManager &&
+      window.game.inputManager.keyMap['KeyF'] === 'fullscreen';
+    const wrapperExists = !!window.game.canvas.parentElement;
+
+    return {
+      exists: true,
+      hasToggleMethod,
+      hasKeyMapping,
+      wrapperExists
+    };
+  });
+
+  if (!fsData.exists) {
+    result.status = 'fail';
+    result.note = fsData.reason;
+    return;
+  }
+
+  const checks = [
+    ['toggleFullscreen method', fsData.hasToggleMethod],
+    ['F key mapped to fullscreen', fsData.hasKeyMapping],
+    ['game wrapper exists', fsData.wrapperExists]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = 'Fullscreen toggle available via F key';
   }
 }
 


### PR DESCRIPTION
## Summary
- Press **F** to toggle fullscreen mode on/off
- Game wrapper enters browser fullscreen API, canvas scales to fill screen while maintaining 4:3 aspect ratio
- Proper resize handling for both fullscreen and windowed modes
- CSS styling for fullscreen state (black background, no border)
- Updated controls page and in-game instructions bar

## Test plan
- [x] T2-29 test verifies toggleFullscreen method and F key mapping
- [x] All 38 tests passing, 0 failures

Fixes #48