### PR TITLE
Add automap fog of war system

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -243,6 +243,11 @@ class GameEngine {
             window.applyDifficulty(window.CONFIG.difficulty);
         }
 
+        // Reset fog of war
+        if (this.hud) {
+            this.hud.resetFog();
+        }
+
         // Update renderer with new map
         this.renderer.map = this.map;
 

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -47,6 +47,10 @@ class HUD {
         this.killFeedMax = 4;
         this.killFeedDuration = 3000; // 3 seconds
 
+        // Fog of war
+        this.revealedTiles = new Set();
+        this.fogRevealRadius = 4; // tiles
+
         console.log('HUD system initialized');
     }
     
@@ -866,12 +870,41 @@ class HUD {
         }
     }
     
+    updateFogOfWar(player, map) {
+        const tileX = Math.floor(player.x / map.tileSize);
+        const tileY = Math.floor(player.y / map.tileSize);
+        const r = this.fogRevealRadius;
+
+        for (let dy = -r; dy <= r; dy++) {
+            for (let dx = -r; dx <= r; dx++) {
+                if (dx * dx + dy * dy <= r * r) {
+                    const gx = tileX + dx;
+                    const gy = tileY + dy;
+                    if (gx >= 0 && gx < map.width && gy >= 0 && gy < map.height) {
+                        this.revealedTiles.add(gx + ',' + gy);
+                    }
+                }
+            }
+        }
+    }
+
+    resetFog() {
+        this.revealedTiles = new Set();
+    }
+
+    isTileRevealed(gx, gy) {
+        return this.revealedTiles.has(gx + ',' + gy);
+    }
+
     renderMinimap(player, gameEngine) {
         const map = gameEngine.map;
         const size = 150;
         const padding = 10;
         const mapX = this.canvas.width - size - padding;
         const mapY = padding;
+
+        // Update fog of war
+        this.updateFogOfWar(player, map);
 
         // Semi-transparent background
         this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
@@ -882,9 +915,20 @@ class HUD {
         const cellW = size / map.width;
         const cellH = size / map.height;
 
-        // Draw walls
+        // Draw walls and floors (only revealed tiles)
         for (let gy = 0; gy < map.height; gy++) {
             for (let gx = 0; gx < map.width; gx++) {
+                if (!this.isTileRevealed(gx, gy)) {
+                    // Fog: dark tile
+                    this.ctx.fillStyle = 'rgba(10, 10, 10, 0.8)';
+                    this.ctx.fillRect(
+                        mapX + gx * cellW,
+                        mapY + gy * cellH,
+                        Math.ceil(cellW),
+                        Math.ceil(cellH)
+                    );
+                    continue;
+                }
                 if (map.grid[gy][gx] > 0) {
                     const wallType = map.grid[gy][gx];
                     switch (wallType) {
@@ -907,11 +951,12 @@ class HUD {
             }
         }
 
-        // Draw acid tiles
+        // Draw acid tiles (only in revealed areas)
         if (map.acidTiles) {
             this.ctx.fillStyle = 'rgba(0, 255, 0, 0.4)';
             for (const key of map.acidTiles) {
                 const [ax, ay] = key.split(',').map(Number);
+                if (!this.isTileRevealed(ax, ay)) continue;
                 this.ctx.fillRect(
                     mapX + ax * cellW,
                     mapY + ay * cellH,
@@ -921,10 +966,13 @@ class HUD {
             }
         }
 
-        // Draw barrels
+        // Draw barrels (only in revealed areas)
         if (map.barrels) {
             for (const barrel of map.barrels) {
                 if (!barrel.active) continue;
+                const bgx = Math.floor(barrel.x / map.tileSize);
+                const bgy = Math.floor(barrel.y / map.tileSize);
+                if (!this.isTileRevealed(bgx, bgy)) continue;
                 const bx = mapX + (barrel.x / map.tileSize) * cellW;
                 const by = mapY + (barrel.y / map.tileSize) * cellH;
                 this.ctx.fillStyle = '#CC4400';
@@ -934,11 +982,14 @@ class HUD {
             }
         }
 
-        // Draw weapon pickups
+        // Draw weapon pickups (only in revealed areas)
         if (gameEngine.pickupManager) {
             const pickups = gameEngine.pickupManager.getActivePickups();
             for (const pickup of pickups) {
                 if (!pickup.type.startsWith('weapon_')) continue;
+                const pgx = Math.floor(pickup.x / map.tileSize);
+                const pgy = Math.floor(pickup.y / map.tileSize);
+                if (!this.isTileRevealed(pgx, pgy)) continue;
                 const wx = mapX + (pickup.x / map.tileSize) * cellW;
                 const wy = mapY + (pickup.y / map.tileSize) * cellH;
                 this.ctx.fillStyle = pickup.properties.color;
@@ -948,10 +999,13 @@ class HUD {
             }
         }
 
-        // Draw enemies
+        // Draw enemies (only in revealed areas)
         const enemies = map.enemies;
         for (const enemy of enemies) {
             if (!enemy.active) continue;
+            const egx = Math.floor(enemy.x / map.tileSize);
+            const egy = Math.floor(enemy.y / map.tileSize);
+            if (!this.isTileRevealed(egx, egy)) continue;
             const ex = mapX + (enemy.x / map.tileSize) * cellW;
             const ey = mapY + (enemy.y / map.tileSize) * cellH;
             this.ctx.fillStyle = enemy.type === 'boss' ? '#FFD700' : '#FF4444';

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -617,6 +617,7 @@ const TIER_2_TESTS = [
   { id: 'T2-27', name: 'Environmental hazards', fn: T2_27_environmentalHazards }, // issue: #46
   { id: 'T2-28', name: 'Kill feed system', fn: T2_28_killFeed }, // issue: #47
   { id: 'T2-29', name: 'Fullscreen support', fn: T2_29_fullscreenSupport }, // issue: #48
+  { id: 'T2-30', name: 'Automap fog of war', fn: T2_30_automapFogOfWar }, // issue: #52
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -2215,6 +2216,89 @@ async function T2_29_fullscreenSupport(page, result) {
   } else {
     result.status = 'pass';
     result.note = 'Fullscreen toggle available via F key';
+  }
+}
+
+async function T2_30_automapFogOfWar(page, result) {
+  // T2-30: Automap fog of war (issue: #52)
+  // Pass condition: revealedTiles set exists, fog methods present, tiles near player are revealed
+  await page.waitForTimeout(1000);
+
+  const fogData = await page.evaluate(() => {
+    if (!window.game || !window.game.hud) {
+      return { exists: false, reason: 'HUD not found' };
+    }
+
+    const hud = window.game.hud;
+    const map = window.game.map;
+    const player = window.game.player;
+
+    const hasRevealedTiles = hud.revealedTiles instanceof Set;
+    const hasUpdateFog = typeof hud.updateFogOfWar === 'function';
+    const hasResetFog = typeof hud.resetFog === 'function';
+    const hasIsTileRevealed = typeof hud.isTileRevealed === 'function';
+    const hasRevealRadius = typeof hud.fogRevealRadius === 'number' && hud.fogRevealRadius >= 3;
+
+    // Check player's current tile is revealed
+    const playerTileX = Math.floor(player.x / map.tileSize);
+    const playerTileY = Math.floor(player.y / map.tileSize);
+    const playerTileRevealed = hasIsTileRevealed && hud.isTileRevealed(playerTileX, playerTileY);
+
+    // Count revealed vs total
+    const revealedCount = hasRevealedTiles ? hud.revealedTiles.size : 0;
+    const totalTiles = map.width * map.height;
+    const notFullyRevealed = revealedCount < totalTiles;
+
+    // Test reset
+    let resetWorks = false;
+    if (hasResetFog && hasRevealedTiles) {
+      const before = hud.revealedTiles.size;
+      hud.resetFog();
+      resetWorks = hud.revealedTiles.size === 0;
+      // Re-update to restore state
+      if (hasUpdateFog) hud.updateFogOfWar(player, map);
+    }
+
+    return {
+      exists: true,
+      hasRevealedTiles,
+      hasUpdateFog,
+      hasResetFog,
+      hasIsTileRevealed,
+      hasRevealRadius,
+      playerTileRevealed,
+      revealedCount,
+      totalTiles,
+      notFullyRevealed,
+      resetWorks
+    };
+  });
+
+  if (!fogData.exists) {
+    result.status = 'fail';
+    result.note = fogData.reason;
+    return;
+  }
+
+  const checks = [
+    ['revealedTiles set', fogData.hasRevealedTiles],
+    ['updateFogOfWar method', fogData.hasUpdateFog],
+    ['resetFog method', fogData.hasResetFog],
+    ['isTileRevealed method', fogData.hasIsTileRevealed],
+    ['reveal radius >= 3', fogData.hasRevealRadius],
+    ['player tile revealed', fogData.playerTileRevealed],
+    ['not fully revealed', fogData.notFullyRevealed],
+    ['reset clears tiles', fogData.resetWorks]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Fog of war: ${fogData.revealedCount}/${fogData.totalTiles} tiles revealed, radius ${fogData.hasRevealRadius ? '4' : '?'}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Unexplored areas appear dark on the minimap with fog of war
- Player movement reveals nearby tiles within a 4-tile radius (circular)
- Enemies, weapon pickups, barrels, and acid tiles only visible in revealed areas
- Revealed areas stay visible permanently for the run
- Fog resets on level restart

## Test plan
- [x] T2-30 test verifies fog system (revealedTiles set, fog methods, partial reveal, reset)
- [x] All 39 tests passing, 0 failures

Fixes #52