### PR TITLE
Add ammo crates that drop from killed enemies

### DIFF
--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -283,6 +283,11 @@ class Enemy {
             if (window.soundEngine && window.soundEngine.isInitialized) {
                 window.soundEngine.playEnemyDeath();
             }
+
+            // 30% chance to drop an ammo crate
+            if (Math.random() < 0.3 && window.game && window.game.pickupManager) {
+                window.game.pickupManager.spawnAmmoCrate(this.x, this.y);
+            }
         }
 
         return actualDamage;

--- a/js/entities/pickup.js
+++ b/js/entities/pickup.js
@@ -506,6 +506,28 @@ class PickupManager {
         }
     }
 
+    // Spawn an ammo crate at a given position for a random unlocked weapon
+    spawnAmmoCrate(x, y) {
+        if (!window.game || !window.game.player) return null;
+
+        const wm = window.game.player.weaponManager;
+        const unlocked = Array.from(wm.unlockedWeapons);
+        if (unlocked.length === 0) return null;
+
+        const weaponType = unlocked[Math.floor(Math.random() * unlocked.length)];
+        const ammoType = 'ammo_' + weaponType;
+
+        const pickup = this.addPickup(x, y, ammoType);
+        console.log(`Ammo crate dropped: ${ammoType} at (${Math.round(x)}, ${Math.round(y)})`);
+
+        // Kill feed message
+        if (window.game.hud && window.game.hud.addKillFeedMessage) {
+            window.game.hud.addKillFeedMessage('Ammo crate dropped!', '#FFFF00');
+        }
+
+        return pickup;
+    }
+
     // Spawn random pickups around the map
     spawnRandomPickups(map, count = 5) {
         const pickupTypes = ['health', 'ammo_pistol', 'ammo_shotgun', 'ammo_rifle', 'ammo_rocket', 'ammo_chaingun', 'armor'];

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -618,6 +618,7 @@ const TIER_2_TESTS = [
   { id: 'T2-28', name: 'Kill feed system', fn: T2_28_killFeed }, // issue: #47
   { id: 'T2-29', name: 'Fullscreen support', fn: T2_29_fullscreenSupport }, // issue: #48
   { id: 'T2-30', name: 'Automap fog of war', fn: T2_30_automapFogOfWar }, // issue: #52
+  { id: 'T2-31', name: 'Ammo crate drops', fn: T2_31_ammoCrateDrops }, // issue: #53
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -2299,6 +2300,80 @@ async function T2_30_automapFogOfWar(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Fog of war: ${fogData.revealedCount}/${fogData.totalTiles} tiles revealed, radius ${fogData.hasRevealRadius ? '4' : '?'}`;
+  }
+}
+
+async function T2_31_ammoCrateDrops(page, result) {
+  // T2-31: Ammo crate drops from enemies (issue: #53)
+  // Pass condition: PickupManager has spawnAmmoCrate, enemies can trigger drops, crate spawns at position
+  await page.waitForTimeout(1000);
+
+  const dropData = await page.evaluate(() => {
+    if (!window.game || !window.game.pickupManager) {
+      return { exists: false, reason: 'Pickup manager not found' };
+    }
+
+    const pm = window.game.pickupManager;
+    const player = window.game.player;
+
+    const hasSpawnMethod = typeof pm.spawnAmmoCrate === 'function';
+
+    // Test spawning an ammo crate
+    let spawnWorks = false;
+    let spawnedType = null;
+    if (hasSpawnMethod) {
+      const before = pm.pickups.length;
+      const crate = pm.spawnAmmoCrate(200, 200);
+      if (crate && pm.pickups.length === before + 1) {
+        spawnWorks = true;
+        spawnedType = crate.type;
+        // Clean up
+        crate.active = false;
+        pm.pickups = pm.pickups.filter(p => p.active);
+      }
+    }
+
+    // Check enemy drop code exists (enemy has takeDamage that can drop)
+    const enemies = window.game.map.enemies;
+    const hasEnemies = enemies.length > 0;
+    let enemyDropCodeExists = false;
+    if (hasEnemies) {
+      const enemy = enemies[0];
+      const src = enemy.takeDamage.toString();
+      enemyDropCodeExists = src.includes('spawnAmmoCrate') || src.includes('ammoCrate');
+    }
+
+    return {
+      exists: true,
+      hasSpawnMethod,
+      spawnWorks,
+      spawnedType,
+      hasEnemies,
+      enemyDropCodeExists
+    };
+  });
+
+  if (!dropData.exists) {
+    result.status = 'fail';
+    result.note = dropData.reason;
+    return;
+  }
+
+  const checks = [
+    ['spawnAmmoCrate method', dropData.hasSpawnMethod],
+    ['crate spawns correctly', dropData.spawnWorks],
+    ['spawned ammo type', dropData.spawnedType && dropData.spawnedType.startsWith('ammo_')],
+    ['enemy drop code exists', dropData.enemyDropCodeExists]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Ammo drops: spawn works (${dropData.spawnedType}), 30% chance on enemy death`;
   }
 }
 


### PR DESCRIPTION
## Summary
- 30% chance for an enemy to drop an ammo crate on death
- Crate type matches a random unlocked weapon from the player's arsenal
- Uses the existing pickup system for auto-collection when player walks over
- Kill feed notification shows when an ammo crate drops

## Test plan
- [x] T2-31 test verifies spawnAmmoCrate method, crate spawning, and enemy drop code
- [x] All 40 tests passing, 0 failures

Fixes #53