### PR TITLE
Add door opening/closing animation

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -168,8 +168,8 @@ class GameEngine {
         // Update pickups
         this.pickupManager.update(deltaTime, this.player);
 
-        // Update doors
-        this.map.updateDoors();
+        // Update doors (proximity-based opening + animation)
+        this.map.updateDoors(this.player.x, this.player.y, deltaTime);
 
         // Acid pool damage (5 HP/sec for player and enemies)
         if (this.map.isAcidAtPosition(this.player.x, this.player.y)) {

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -146,7 +146,7 @@ class Renderer {
             const mapX = Math.floor(rayX / this.wallHeight);
             const mapY = Math.floor(rayY / this.wallHeight);
             
-            if (this.map.isWall(mapX, mapY)) {
+            if (this.map.isRayWall(mapX, mapY)) {
                 hitWall = true;
                 wallType = this.map.getWallType(mapX, mapY);
                 
@@ -185,18 +185,35 @@ class Renderer {
         
         // Calculate wall height on screen
         const wallScreenHeight = (this.wallHeight * this.projectionDistance) / distance;
-        const wallTop = this.halfHeight - wallScreenHeight / 2;
-        const wallBottom = this.halfHeight + wallScreenHeight / 2;
-        
+        let wallTop = this.halfHeight - wallScreenHeight / 2;
+        let wallBottom = this.halfHeight + wallScreenHeight / 2;
+
+        // Door animation: slide door upward based on progress
+        let doorProgress = 0;
+        if (wallType === 9) {
+            const doorMapX = Math.floor(hitX / this.wallHeight);
+            const doorMapY = Math.floor(hitY / this.wallHeight);
+            const door = this.map.getDoorAt(doorMapX, doorMapY);
+            if (door) doorProgress = door.progress;
+        }
+
+        // For doors: shrink the visible wall from bottom (door slides up)
+        let doorWallTop = wallTop;
+        let doorWallBottom = wallBottom;
+        if (doorProgress > 0) {
+            doorWallBottom = wallBottom - wallScreenHeight * doorProgress;
+            doorWallTop = wallTop; // Top stays; door goes up into ceiling
+        }
+
         // Get texture for this wall type
         const textureName = this.wallTypeTextures[wallType] || 'stone';
         const texture = this.textures[textureName];
-        
+
         // Apply shading based on distance and wall side
         const shadingFactor = Math.max(0.2, 1 - (distance / this.maxRenderDistance));
         const sideFactor = hitSide === 0 ? 1.0 : 0.7; // Darken horizontal walls
         const totalShading = shadingFactor * sideFactor;
-        
+
         // Calculate texture U coordinate (horizontal position on texture)
         let textureU;
         if (hitSide === 0) {
@@ -206,33 +223,37 @@ class Renderer {
             // Horizontal wall - use X coordinate
             textureU = (hitX % this.wallHeight) / this.wallHeight;
         }
-        
-        // Render floor
+
+        // Render ceiling (above wall on screen)
         for (let y = 0; y < wallTop && y < this.height; y++) {
             this.setPixel(x, Math.floor(y), this.hexToRgb(this.floorColor));
         }
-        
-        // Render textured wall
+
+        // Render textured wall (use door-adjusted bounds for doors)
+        const renderTop = doorProgress > 0 ? doorWallTop : wallTop;
+        const renderBottom = doorProgress > 0 ? doorWallBottom : wallBottom;
+
         if (texture && texture.complete) {
-            this.renderTexturedWallSlice(x, wallTop, wallBottom, textureU, texture, totalShading);
+            this.renderTexturedWallSlice(x, renderTop, renderBottom, textureU, texture, totalShading);
         } else {
             // Fallback to solid color if texture not loaded
             let wallColor = this.wallColors[wallType] || '#FFFFFF';
             const color = this.applyShading(wallColor, totalShading);
-            
-            for (let y = Math.max(0, wallTop); y < Math.min(this.height, wallBottom); y++) {
+
+            for (let y = Math.max(0, renderTop); y < Math.min(this.height, renderBottom); y++) {
                 this.setPixel(x, Math.floor(y), color);
             }
         }
         
-        // Render floor (below wall on screen)
+        // Render floor (below wall on screen, or below door gap)
+        const floorStartY = doorProgress > 0 ? Math.ceil(doorWallBottom) : Math.ceil(wallBottom);
         if (this._acidTileCount > 0) {
             const rayAngle = rayResult.angle;
             const cosAngle = Math.cos(rayAngle);
             const sinAngle = Math.sin(rayAngle);
             const cosCorrection = Math.cos(rayAngle - player.angle);
             const baseFloorColor = this.hexToRgb(this.ceilingColor);
-            for (let y = Math.max(0, Math.ceil(wallBottom)); y < this.height; y++) {
+            for (let y = Math.max(0, floorStartY); y < this.height; y++) {
                 const rowDist = (this.halfHeight * this.wallHeight) / (y - this.halfHeight);
                 const actualDist = rowDist / cosCorrection;
                 const floorWorldX = player.x + actualDist * cosAngle;
@@ -252,7 +273,7 @@ class Renderer {
                 }
             }
         } else {
-            for (let y = Math.max(0, Math.ceil(wallBottom)); y < this.height; y++) {
+            for (let y = Math.max(0, floorStartY); y < this.height; y++) {
                 this.setPixel(x, Math.floor(y), this.hexToRgb(this.ceilingColor));
             }
         }

--- a/js/world/map.js
+++ b/js/world/map.js
@@ -143,10 +143,12 @@ class GameMap {
 
         this.doors.push({
             mapX, mapY,
-            isOpen: false,
             keyRequired, // 'none', 'red', 'blue', 'yellow'
-            openTime: 0,
-            autoCloseDelay: 5000 // Close after 5 seconds
+            state: 'closed', // closed, opening, open, closing
+            progress: 0, // 0.0 = closed, 1.0 = fully open
+            lastProximityTime: 0,
+            autoCloseDelay: 3000, // Close 3 seconds after player leaves
+            animDuration: 500 // 0.5 seconds to open/close
         });
     }
 
@@ -159,8 +161,7 @@ class GameMap {
 
         for (const door of this.doors) {
             if (door.mapX === mapPos.x && door.mapY === mapPos.y) {
-                if (door.isOpen) {
-                    // Already open
+                if (door.state === 'open' || door.state === 'opening') {
                     return { success: false, reason: 'already_open' };
                 }
 
@@ -171,10 +172,9 @@ class GameMap {
                     }
                 }
 
-                // Open the door
-                door.isOpen = true;
-                door.openTime = Date.now();
-                this.grid[door.mapY][door.mapX] = 0; // Remove wall
+                // Start opening the door
+                door.state = 'opening';
+                door.lastProximityTime = Date.now();
 
                 // Play door sound
                 if (window.soundEngine && window.soundEngine.isInitialized) {
@@ -188,15 +188,81 @@ class GameMap {
         return { success: false, reason: 'no_door' };
     }
 
-    updateDoors() {
+    updateDoors(playerX, playerY, deltaTime) {
         const now = Date.now();
+        const proximityRange = 2 * this.tileSize; // 2 tiles
+
         for (const door of this.doors) {
-            // Auto-close doors after delay
-            if (door.isOpen && now - door.openTime > door.autoCloseDelay) {
-                door.isOpen = false;
-                this.grid[door.mapY][door.mapX] = 9;
+            // Calculate distance from player to door center
+            const doorWorldX = door.mapX * this.tileSize + this.tileSize / 2;
+            const doorWorldY = door.mapY * this.tileSize + this.tileSize / 2;
+            const dx = playerX - doorWorldX;
+            const dy = playerY - doorWorldY;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            const playerNearby = dist < proximityRange;
+
+            if (playerNearby) {
+                door.lastProximityTime = now;
+
+                // Auto-open unlocked doors on proximity
+                if (door.state === 'closed' && door.keyRequired === 'none') {
+                    door.state = 'opening';
+                    if (window.soundEngine && window.soundEngine.isInitialized) {
+                        window.soundEngine.playDoorSound();
+                    }
+                } else if (door.state === 'closing' && door.keyRequired === 'none') {
+                    door.state = 'opening';
+                    if (window.soundEngine && window.soundEngine.isInitialized) {
+                        window.soundEngine.playDoorSound();
+                    }
+                }
+            }
+
+            // Animate door based on state
+            const animStep = (deltaTime || 0.016) / (door.animDuration / 1000);
+
+            if (door.state === 'opening') {
+                door.progress = Math.min(1.0, door.progress + animStep);
+                if (door.progress >= 1.0) {
+                    door.state = 'open';
+                    door.progress = 1.0;
+                }
+            } else if (door.state === 'closing') {
+                door.progress = Math.max(0.0, door.progress - animStep);
+                if (door.progress <= 0.0) {
+                    door.state = 'closed';
+                    door.progress = 0.0;
+                    this.grid[door.mapY][door.mapX] = 9; // Restore wall collision
+                }
+            } else if (door.state === 'open') {
+                // Auto-close after delay when player is far enough away
+                if (!playerNearby && now - door.lastProximityTime > door.autoCloseDelay) {
+                    // Check if any entity is in the door tile before closing
+                    if (!this._isEntityInTile(door.mapX, door.mapY, playerX, playerY)) {
+                        door.state = 'closing';
+                        if (window.soundEngine && window.soundEngine.isInitialized) {
+                            window.soundEngine.playDoorSound();
+                        }
+                    }
+                }
             }
         }
+    }
+
+    _isEntityInTile(mapX, mapY, playerX, playerY) {
+        // Check if player is in this tile
+        const pMapX = Math.floor(playerX / this.tileSize);
+        const pMapY = Math.floor(playerY / this.tileSize);
+        if (pMapX === mapX && pMapY === mapY) return true;
+
+        // Check if any enemy is in this tile
+        for (const enemy of this.enemies) {
+            if (!enemy.active) continue;
+            const eMapX = Math.floor(enemy.x / this.tileSize);
+            const eMapY = Math.floor(enemy.y / this.tileSize);
+            if (eMapX === mapX && eMapY === mapY) return true;
+        }
+        return false;
     }
 
     getDoorAt(mapX, mapY) {
@@ -286,12 +352,33 @@ class GameMap {
         });
     }
 
-    // Check if a coordinate contains a wall
+    // Check if a coordinate contains a wall (for entity collision)
+    // Doors that are partially open allow passage
     isWall(mapX, mapY) {
         if (mapX < 0 || mapX >= this.width || mapY < 0 || mapY >= this.height) {
             return true; // Treat out-of-bounds as walls
         }
-        return this.grid[mapY][mapX] > 0;
+        const val = this.grid[mapY][mapX];
+        if (val === 0) return false;
+        if (val === 9) {
+            const door = this.getDoorAt(mapX, mapY);
+            if (door && door.progress > 0.3) return false;
+        }
+        return true;
+    }
+
+    // Check if a coordinate blocks raycasting (doors block rays until fully open)
+    isRayWall(mapX, mapY) {
+        if (mapX < 0 || mapX >= this.width || mapY < 0 || mapY >= this.height) {
+            return true;
+        }
+        const val = this.grid[mapY][mapX];
+        if (val === 0) return false;
+        if (val === 9) {
+            const door = this.getDoorAt(mapX, mapY);
+            if (door && door.progress >= 1.0) return false;
+        }
+        return true;
     }
     
     // Get wall type at coordinate

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -619,6 +619,7 @@ const TIER_2_TESTS = [
   { id: 'T2-29', name: 'Fullscreen support', fn: T2_29_fullscreenSupport }, // issue: #48
   { id: 'T2-30', name: 'Automap fog of war', fn: T2_30_automapFogOfWar }, // issue: #52
   { id: 'T2-31', name: 'Ammo crate drops', fn: T2_31_ammoCrateDrops }, // issue: #53
+  { id: 'T2-32', name: 'Door animation system', fn: T2_32_doorAnimation }, // issue: #58
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -2374,6 +2375,111 @@ async function T2_31_ammoCrateDrops(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Ammo drops: spawn works (${dropData.spawnedType}), 30% chance on enemy death`;
+  }
+}
+
+async function T2_32_doorAnimation(page, result) {
+  // T2-32: Door opening/closing animation (issue: #58)
+  // Pass condition: Doors have state machine, proximity detection, animation progress
+  await page.waitForTimeout(1000);
+
+  const doorData = await page.evaluate(() => {
+    if (!window.game || !window.game.map) {
+      return { exists: false, reason: 'Game map not found' };
+    }
+
+    const map = window.game.map;
+    const doors = map.doors;
+
+    if (!doors || doors.length === 0) {
+      return { exists: false, reason: 'No doors found' };
+    }
+
+    // Check door data structure
+    const door = doors[0];
+    const hasState = 'state' in door;
+    const hasProgress = 'progress' in door;
+    const hasAnimDuration = 'animDuration' in door;
+    const hasAutoCloseDelay = 'autoCloseDelay' in door;
+
+    // Check methods
+    const hasUpdateDoors = typeof map.updateDoors === 'function';
+    const hasIsRayWall = typeof map.isRayWall === 'function';
+    const hasGetDoorAt = typeof map.getDoorAt === 'function';
+
+    // Test proximity-based opening: move player near a door
+    const testDoor = doors.find(d => d.keyRequired === 'none');
+    let proximityWorks = false;
+    if (testDoor && hasUpdateDoors) {
+      const doorWorldX = testDoor.mapX * map.tileSize + map.tileSize / 2;
+      const doorWorldY = testDoor.mapY * map.tileSize + map.tileSize / 2;
+
+      // Simulate being near the door
+      testDoor.state = 'closed';
+      testDoor.progress = 0;
+      map.grid[testDoor.mapY][testDoor.mapX] = 9;
+      map.updateDoors(doorWorldX, doorWorldY - map.tileSize, 0.016);
+      proximityWorks = testDoor.state === 'opening';
+
+      // Reset
+      testDoor.state = 'closed';
+      testDoor.progress = 0;
+      map.grid[testDoor.mapY][testDoor.mapX] = 9;
+    }
+
+    // Test animation progress
+    let animWorks = false;
+    if (testDoor) {
+      testDoor.state = 'opening';
+      testDoor.progress = 0;
+      map.updateDoors(0, 0, 0.5); // Far from door, 0.5s delta
+      animWorks = testDoor.progress > 0;
+
+      // Reset
+      testDoor.state = 'closed';
+      testDoor.progress = 0;
+      map.grid[testDoor.mapY][testDoor.mapX] = 9;
+    }
+
+    return {
+      exists: true,
+      doorCount: doors.length,
+      hasState,
+      hasProgress,
+      hasAnimDuration,
+      hasAutoCloseDelay,
+      hasUpdateDoors,
+      hasIsRayWall,
+      hasGetDoorAt,
+      proximityWorks,
+      animWorks
+    };
+  });
+
+  if (!doorData.exists) {
+    result.status = 'fail';
+    result.note = doorData.reason;
+    return;
+  }
+
+  const checks = [
+    ['door state field', doorData.hasState],
+    ['door progress field', doorData.hasProgress],
+    ['animation duration', doorData.hasAnimDuration],
+    ['updateDoors method', doorData.hasUpdateDoors],
+    ['isRayWall method', doorData.hasIsRayWall],
+    ['proximity opening', doorData.proximityWorks],
+    ['animation progress', doorData.animWorks]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Door animation: ${doorData.doorCount} doors, state machine + proximity + animation`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Doors auto-open when player approaches within 2 tiles (proximity-based)
- Smooth 0.5s slide-up animation using a state machine (closed → opening → open → closing)
- Doors auto-close 3 seconds after player leaves proximity
- Raycaster renders doors at reduced height based on animation progress
- Safety check prevents doors from closing on entities standing in the doorway
- Locked doors (red key) still require E key interaction

Fixes #58

## Test plan
- [x] All 41 tests pass (40 existing + 1 new T2-32)
- [x] New test verifies door state machine, proximity detection, and animation progress
- [x] FPS remains above minimum threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)