### PR TITLE
#79 Fix acid tiles sliding based on perspective

### DIFF
--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -252,9 +252,10 @@ class Renderer {
             const cosAngle = Math.cos(rayAngle);
             const sinAngle = Math.sin(rayAngle);
             const cosCorrection = Math.cos(rayAngle - player.angle);
-            const baseFloorColor = this.hexToRgb(this.ceilingColor);
+            const baseFloorColor = this.hexToRgb(this.floorColor);
+            const floorDistCoeff = (this.wallHeight / 2) * this.projectionDistance;
             for (let y = Math.max(0, floorStartY); y < this.height; y++) {
-                const rowDist = (this.halfHeight * this.wallHeight) / (y - this.halfHeight);
+                const rowDist = floorDistCoeff / (y - this.halfHeight);
                 const actualDist = rowDist / cosCorrection;
                 const floorWorldX = player.x + actualDist * cosAngle;
                 const floorWorldY = player.y + actualDist * sinAngle;
@@ -288,8 +289,9 @@ class Renderer {
             const sinAngle = Math.sin(rayAngle);
             const cosCorrection = Math.cos(rayAngle - player.angle);
             const baseFloorColor = this.hexToRgb(this.floorColor);
+            const floorDistCoeff = (this.wallHeight / 2) * this.projectionDistance;
             for (let y = Math.ceil(this.halfHeight); y < this.height; y++) {
-                const rowDist = (this.halfHeight * this.wallHeight) / (y - this.halfHeight);
+                const rowDist = floorDistCoeff / (y - this.halfHeight);
                 const actualDist = rowDist / cosCorrection;
                 const floorWorldX = player.x + actualDist * cosAngle;
                 const floorWorldY = player.y + actualDist * sinAngle;


### PR DESCRIPTION
## Summary
- Fixed floor distance calculation to use correct projection formula: `(wallHeight/2) * projectionDistance / (y - halfHeight)` instead of the incorrect `halfHeight * wallHeight / (y - halfHeight)`
- The old formula had a ~15% distance mismatch versus wall rendering, causing acid floor tiles to appear to drift/slide relative to walls when moving around
- Applied fix in both `renderWallSlice` and `renderFloorCeiling` methods
- Also fixed a minor bug where floor color in `renderWallSlice` used `ceilingColor` instead of `floorColor`

Fixes #79

## Test plan
- [x] All 43 tests pass (3 vision tests skipped as expected)
- [x] Floor rendering distance now matches wall rendering projection geometry

🤖 Generated with [Claude Code](https://claude.com/claude-code)