### PR TITLE
#84 Fix directional damage indicators for all enemy types

### DIFF
--- a/js/entities/enemy-behaviors.js
+++ b/js/entities/enemy-behaviors.js
@@ -561,7 +561,7 @@ class EnhancedEnemyAI {
             if (player.takeDamage(damage)) {
                 // Trigger HUD damage flash
                 if (window.game && window.game.hud) {
-                    window.game.hud.onPlayerDamage();
+                    window.game.hud.onPlayerDamageFrom(this.enemy.x, this.enemy.y);
                 }
 
                 // Play attack and pain sounds

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -49,7 +49,7 @@ class HUD {
 
         // Damage direction indicators
         this.damageIndicators = [];
-        this.damageIndicatorDuration = 500; // 0.5 seconds
+        this.damageIndicatorDuration = 1000; // 1 second
 
         // Fog of war
         this.revealedTiles = new Set();


### PR DESCRIPTION
## Summary
- Fixed `enemy-behaviors.js` to pass enemy position to `onPlayerDamageFrom()` so all advanced enemy behaviors (berserker, spitter, shield_guard, etc.) correctly show directional damage indicators
- Increased indicator fade duration from 500ms to 1000ms for better visibility during combat

## Test plan
- [x] All 43 tests pass (3 vision tests skipped)
- [x] T2-33 specifically validates damage direction indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)