### PR TITLE
Add weapon upgrade pickups

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -89,6 +89,7 @@ class GameEngine {
         this.pickupManager = new PickupManager();
         this.pickupManager.spawnWeaponPickups(this.map);
         this.pickupManager.spawnRandomPickups(this.map, 6);
+        this.pickupManager.spawnModPickups(this.map);
         console.log('Pickup system initialized');
         
         // Bind debug toggle
@@ -193,6 +194,7 @@ class GameEngine {
         this.pickupManager = new PickupManager();
         this.pickupManager.spawnWeaponPickups(this.map);
         this.pickupManager.spawnRandomPickups(this.map, 6);
+        this.pickupManager.spawnModPickups(this.map);
         this.hud.resetFog();
         this.levelStartTime = performance.now();
         this.totalEnemyCount = this.map.enemies.length;
@@ -505,6 +507,7 @@ class GameEngine {
         this.pickupManager = new PickupManager();
         this.pickupManager.spawnWeaponPickups(this.map);
         this.pickupManager.spawnRandomPickups(this.map, 6);
+        this.pickupManager.spawnModPickups(this.map);
 
         // Re-apply difficulty
         if (window.CONFIG && window.CONFIG.difficulty) {

--- a/js/entities/pickup.js
+++ b/js/entities/pickup.js
@@ -149,6 +149,27 @@ class Pickup {
                 maxValue: 0,
                 sound: 'weapon',
                 message: 'Chaingun Acquired!'
+            },
+            mod_armor_piercing: {
+                value: 0,
+                color: '#FF2222',
+                maxValue: 0,
+                sound: 'powerup',
+                message: 'Armor-Piercing Rounds!'
+            },
+            mod_rapid_fire: {
+                value: 0,
+                color: '#22FF88',
+                maxValue: 0,
+                sound: 'powerup',
+                message: 'Rapid-Fire Mod!'
+            },
+            mod_extended_mag: {
+                value: 0,
+                color: '#2288FF',
+                maxValue: 0,
+                sound: 'powerup',
+                message: 'Extended Magazine!'
             }
         };
         
@@ -165,8 +186,8 @@ class Pickup {
         // Animate bobbing
         this.bobOffset += this.bobSpeed * deltaTime;
         
-        // Animate rotation for power-ups and weapon pickups
-        if (this.type.includes('boost') || this.type.startsWith('weapon_')) {
+        // Animate rotation for power-ups, weapon pickups, and mods
+        if (this.type.includes('boost') || this.type.startsWith('weapon_') || this.type.startsWith('mod_')) {
             this.rotation += this.rotationSpeed * deltaTime;
         }
         
@@ -276,6 +297,18 @@ class Pickup {
                 if (!player.weaponManager.isUnlocked(weaponName)) {
                     player.weaponManager.unlockWeapon(weaponName);
                     player.weaponManager.switchWeapon(weaponName);
+                    canCollect = true;
+                }
+                break;
+            }
+
+            case 'mod_armor_piercing':
+            case 'mod_rapid_fire':
+            case 'mod_extended_mag': {
+                const modName = this.type.replace('mod_', '');
+                const currentWeapon = player.weaponManager.getCurrentWeapon();
+                if (!currentWeapon.mods.includes(modName)) {
+                    currentWeapon.addMod(modName);
                     canCollect = true;
                 }
                 break;
@@ -526,6 +559,22 @@ class PickupManager {
         }
 
         return pickup;
+    }
+
+    // Spawn weapon mod pickups at strategic locations
+    spawnModPickups(map) {
+        const tileSize = map.tileSize;
+        const modLocations = [
+            { type: 'mod_armor_piercing', x: 14.5 * tileSize, y: 5.5  * tileSize }, // Near reactor entrance
+            { type: 'mod_rapid_fire',     x: 3.5  * tileSize, y: 18.5 * tileSize }, // Waste storage area
+            { type: 'mod_extended_mag',   x: 18.5 * tileSize, y: 18.5 * tileSize }  // Far corner storage
+        ];
+
+        for (const loc of modLocations) {
+            if (!map.isWallAtPosition(loc.x, loc.y)) {
+                this.addPickup(loc.x, loc.y, loc.type);
+            }
+        }
     }
 
     // Spawn random pickups around the map

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -210,7 +210,26 @@ class HUD {
         this.ctx.font = this.largeFont;
         this.ctx.textAlign = 'right';
         this.ctx.fillText(weaponInfo.weaponName, this.canvas.width - 20, y - 15);
-        
+
+        // Active mods display
+        if (weaponInfo.mods && weaponInfo.mods.length > 0) {
+            this.ctx.font = '10px monospace';
+            const modLabels = { armor_piercing: 'AP', rapid_fire: 'RF', extended_mag: 'EXT' };
+            const modColors = { armor_piercing: '#FF4444', rapid_fire: '#22FF88', extended_mag: '#4488FF' };
+            let modX = this.canvas.width - 20;
+            for (let i = weaponInfo.mods.length - 1; i >= 0; i--) {
+                const mod = weaponInfo.mods[i];
+                const label = modLabels[mod] || mod.toUpperCase();
+                const color = modColors[mod] || '#FFFFFF';
+                const tw = this.ctx.measureText(label).width + 8;
+                this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+                this.ctx.fillRect(modX - tw, y - 6, tw, 14);
+                this.ctx.fillStyle = color;
+                this.ctx.fillText(label, modX - 4, y + 5);
+                modX -= tw + 4;
+            }
+        }
+
         // Reload indicator
         if (weaponInfo.isReloading) {
             const progress = weaponInfo.reloadProgress;

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -21,6 +21,9 @@ class Weapon {
         this.muzzleFlash = false;
         this.muzzleFlashDuration = 100; // ms
         this.muzzleFlashStart = 0;
+
+        // Weapon mods (upgrades)
+        this.mods = [];
     }
     
     getWeaponStats(type) {
@@ -80,7 +83,7 @@ class Weapon {
     canFire() {
         const now = Date.now();
         const timeSinceLastShot = now - this.lastFireTime;
-        let fireInterval = 1000 / this.fireRate;
+        let fireInterval = 1000 / this.getModdedFireRate();
 
         // Rapid fire power-up doubles fire rate
         if (window.game && window.game.player && window.game.player.hasRapidFire()) {
@@ -133,8 +136,8 @@ class Weapon {
             // Track hit
             if (player.stats) player.stats.shotsHit++;
 
-            // Calculate damage with accuracy
-            let actualDamage = this.damage;
+            // Calculate damage with accuracy (including mods)
+            let actualDamage = this.getModdedDamage();
             if (Math.random() > this.accuracy) {
                 actualDamage *= 0.3; // Partial damage on inaccurate shots
             }
@@ -383,6 +386,36 @@ class Weapon {
         return xpTable[enemy.type] || 20;
     }
 
+    addMod(modType) {
+        if (this.mods.includes(modType)) return false;
+        this.mods.push(modType);
+
+        // Apply permanent stat changes
+        if (modType === 'extended_mag') {
+            const bonus = Math.floor(this.getWeaponStats(this.type).maxAmmo * 0.5);
+            this.maxAmmo += bonus;
+        }
+
+        console.log(`Mod applied to ${this.type}: ${modType}`);
+        return true;
+    }
+
+    getModdedDamage() {
+        let dmg = this.damage;
+        if (this.mods.includes('armor_piercing')) {
+            dmg = Math.round(dmg * 1.25);
+        }
+        return dmg;
+    }
+
+    getModdedFireRate() {
+        let rate = this.fireRate;
+        if (this.mods.includes('rapid_fire')) {
+            rate *= 1.3;
+        }
+        return rate;
+    }
+
     getAmmoString() {
         return `${this.ammo}/${this.maxAmmo}`;
     }
@@ -458,7 +491,8 @@ class WeaponManager {
             ammo: weapon.getAmmoString(),
             isReloading: weapon.isReloading,
             reloadProgress: weapon.getReloadProgress(),
-            muzzleFlash: weapon.muzzleFlash
+            muzzleFlash: weapon.muzzleFlash,
+            mods: weapon.mods
         };
     }
 }


### PR DESCRIPTION
## Summary
- Add 3 weapon mod types: Armor-Piercing (+25% damage), Rapid-Fire (1.3x fire rate), Extended Magazine (+50% ammo)
- Mods spawn at 3 fixed map locations and apply to the currently equipped weapon on pickup
- HUD displays active mods as colored tags (AP/RF/EXT) below the weapon name
- Mods persist for the session, lost on death/restart

Fixes #93

## Test plan
- [x] All 43 existing tests pass
- [ ] Pick up Armor-Piercing mod, verify increased damage
- [ ] Pick up Rapid-Fire mod, verify faster fire rate
- [ ] Pick up Extended Mag mod, verify increased ammo capacity
- [ ] Verify mod tags display on HUD

🤖 Generated with [Claude Code](https://claude.com/claude-code)