### PR TITLE
#98 Add DailyDoom title to level selection screen

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -241,6 +241,22 @@ a:hover {
     display: none;
 }
 
+.difficulty-overlay .game-logo {
+    font-size: 3rem;
+    font-weight: 900;
+    letter-spacing: 4px;
+    margin-bottom: 12px;
+}
+
+.difficulty-overlay .game-logo .logo-daily {
+    color: #aaa;
+}
+
+.difficulty-overlay .game-logo .logo-doom {
+    color: #ff6b6b;
+    text-shadow: 0 0 30px rgba(255, 107, 107, 0.5);
+}
+
 .difficulty-title {
     font-size: 1.8rem;
     color: #ff6b6b;
@@ -879,6 +895,10 @@ a:hover {
     .difficulty-btn {
         width: 100%;
         max-width: 280px;
+    }
+
+    .difficulty-overlay .game-logo {
+        font-size: 2rem;
     }
 
     .difficulty-title {

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
                 <canvas id="gameCanvas" width="800" height="600"></canvas>
                 <!-- Difficulty Selection Overlay -->
                 <div id="difficultyOverlay" class="difficulty-overlay">
+                    <div class="game-logo"><span class="logo-daily">DAILY</span><span class="logo-doom">DOOM</span></div>
                     <div class="difficulty-title">Choose Your Fate</div>
                     <div class="difficulty-options">
                         <button class="difficulty-btn difficulty-easy" data-difficulty="easy">


### PR DESCRIPTION
## Summary
- Adds the DAILYDOOM game logo to the difficulty selection overlay
- Logo uses the same DAILY/DOOM split styling as the nav bar
- Responsive sizing for mobile screens

## Test plan
- [x] All 43 tests pass
- [x] Verify logo appears above "Choose Your Fate" text
- [x] Check mobile responsive sizing

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)