### PR TITLE
#99 Add enemy death animations with particle effects

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -298,7 +298,7 @@ class GameEngine {
             }
         }
         this.map.enemies.forEach(enemy => {
-            if (!enemy.active) return;
+            if (!enemy.active || enemy.dying) return;
             if (this.map.isAcidAtPosition(enemy.x, enemy.y)) {
                 if (!enemy._lastAcidTick || Date.now() - enemy._lastAcidTick > 500) {
                     enemy.takeDamage(2.5);
@@ -322,7 +322,7 @@ class GameEngine {
     checkLevelComplete() {
         if (this.levelComplete) return;
 
-        const activeEnemies = this.map.enemies.filter(e => e.active);
+        const activeEnemies = this.map.enemies.filter(e => e.active && !e.dying);
         if (activeEnemies.length === 0 && this.totalEnemyCount > 0) {
             this.levelComplete = true;
             this.levelCompleteTime = performance.now();

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -692,8 +692,8 @@ class Renderer {
     }
     
     renderSprites(player) {
-        // Get all active enemies
-        const activeEnemies = this.map.enemies.filter(enemy => enemy.active);
+        // Get all active enemies (including dying ones for death animation)
+        const activeEnemies = this.map.enemies.filter(enemy => enemy.active || enemy.dying);
         
         // Get all active pickups (if pickup manager exists)
         const activePickups = window.game && window.game.pickupManager ? 
@@ -871,19 +871,42 @@ class Renderer {
             const wallScreenHeight = (this.wallHeight * this.projectionDistance) / distance;
             const floorY = this.halfHeight + wallScreenHeight / 2;
 
+            // Death animation: fade out + collapse to floor
+            let deathProgress = 0;
+            if (entity.dying && entity.deathTime) {
+                deathProgress = Math.min(1, (Date.now() - entity.deathTime) / (entity.deathDuration || 600));
+            }
+
+            // Apply death animation transforms
+            const deathAlpha = entity.dying ? 1 - deathProgress * 0.8 : 1;
+            const deathScaleY = entity.dying ? 1 - deathProgress * 0.7 : 1;
+            const adjustedHeight = spriteSize * deathScaleY;
+
             // Draw the sprite with bottom aligned to floor, pixel-art crisp
             const spriteX = screenX - spriteSize / 2;
-            const spriteY = floorY - spriteSize;
+            const spriteY = floorY - adjustedHeight;
             const prevSmoothing = this.ctx.imageSmoothingEnabled;
             this.ctx.imageSmoothingEnabled = false;
-            this.ctx.drawImage(sprite, spriteX, spriteY, spriteSize, spriteSize);
+            this.ctx.globalAlpha = deathAlpha;
+
+            // Red tint during death
+            if (entity.dying) {
+                this.ctx.drawImage(sprite, spriteX, spriteY, spriteSize, adjustedHeight);
+                this.ctx.globalAlpha = deathAlpha * 0.5;
+                this.ctx.fillStyle = '#FF0000';
+                this.ctx.fillRect(spriteX, spriteY, spriteSize, adjustedHeight);
+            } else {
+                this.ctx.drawImage(sprite, spriteX, spriteY, spriteSize, adjustedHeight);
+            }
+
+            this.ctx.globalAlpha = 1.0;
             this.ctx.imageSmoothingEnabled = prevSmoothing;
 
             // Hit flash overlay (red tint for 150ms after being hit)
-            if (entity.hitFlashTime && Date.now() - entity.hitFlashTime < 150) {
+            if (!entity.dying && entity.hitFlashTime && Date.now() - entity.hitFlashTime < 150) {
                 this.ctx.globalAlpha = 0.4;
                 this.ctx.fillStyle = '#FF0000';
-                this.ctx.fillRect(spriteX, spriteY, spriteSize, spriteSize);
+                this.ctx.fillRect(spriteX, spriteY, spriteSize, adjustedHeight);
                 this.ctx.globalAlpha = 1.0;
             }
         } else if (entityType === 'pickup') {

--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -36,6 +36,11 @@ class Enemy {
         this.lastBarkTime = 0;
         this.barkCooldown = 2000; // Minimum 2s between barks
         this.hasPlayedAlert = false;
+
+        // Death animation
+        this.dying = false;
+        this.deathTime = 0;
+        this.deathDuration = 600; // ms for death animation
         
         // Enhanced AI system
         this.enhancedAI = null;
@@ -46,6 +51,14 @@ class Enemy {
     
     update(deltaTime, player, map, allEnemies) {
         if (!this.active) return;
+
+        // Handle death animation timer
+        if (this.dying) {
+            if (Date.now() - this.deathTime >= this.deathDuration) {
+                this.active = false;
+            }
+            return; // No AI updates while dying
+        }
 
         // Use enhanced AI if available
         if (this.enhancedAI) {
@@ -294,13 +307,20 @@ class Enemy {
             this.tryBark('pain');
         }
 
-        if (this.health <= 0) {
-            this.active = false;
+        if (this.health <= 0 && !this.dying) {
+            this.dying = true;
+            this.deathTime = Date.now();
+            this.state = 'dying';
             console.log(`${this.type} destroyed!`);
 
             // Play death sound
             if (window.soundEngine && window.soundEngine.isInitialized) {
                 window.soundEngine.playEnemyDeath();
+            }
+
+            // Emit death particle burst
+            if (window.game && window.game.hud) {
+                window.game.hud.emitBloodParticles(this.x, this.y, 15);
             }
 
             // 30% chance to drop an ammo crate

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -159,12 +159,12 @@ class Weapon {
             }
 
             actualDamage = Math.round(actualDamage);
-            const wasAlive = hit.enemy.active;
+            const wasAlive = !hit.enemy.dying;
             hit.enemy.takeDamage(actualDamage);
 
             // Track damage dealt and kills
             if (player.stats) player.stats.damageDealt += actualDamage;
-            if (wasAlive && !hit.enemy.active) {
+            if (wasAlive && (hit.enemy.dying || !hit.enemy.active)) {
                 if (player.stats) player.stats.enemiesKilled++;
                 // Grant XP based on enemy type
                 const xpReward = this.getKillXP(hit.enemy);
@@ -182,7 +182,7 @@ class Weapon {
             // Trigger enemy hit flash and blood particles
             hit.enemy.hitFlashTime = Date.now();
             if (window.game && window.game.hud) {
-                window.game.hud.emitBloodParticles(hit.enemy.x, hit.enemy.y, wasAlive && !hit.enemy.active ? 12 : 5);
+                window.game.hud.emitBloodParticles(hit.enemy.x, hit.enemy.y, wasAlive && hit.enemy.dying ? 12 : 5);
             }
 
             // Show floating damage number
@@ -222,7 +222,7 @@ class Weapon {
 
             // Damage all enemies in splash radius
             map.enemies.forEach(enemy => {
-                if (!enemy.active) return;
+                if (!enemy.active || enemy.dying) return;
                 if (enemy === hit.enemy) return; // Already took direct hit
                 const dx = enemy.x - hit.hitPoint.x;
                 const dy = enemy.y - hit.hitPoint.y;
@@ -289,7 +289,7 @@ class Weapon {
             
             // Check for enemy collisions
             map.enemies.forEach(enemy => {
-                if (!enemy.active) return;
+                if (!enemy.active || enemy.dying) return;
                 
                 const enemyDistance = Math.sqrt(
                     (enemy.x - currentX) * (enemy.x - currentX) +


### PR DESCRIPTION
## Summary
- Enemies play a 600ms death animation (collapse + red tint + fade) instead of vanishing instantly
- Extra blood particle burst (15 particles) emitted on death
- Dying enemies excluded from hit detection, splash damage, acid damage, and level completion checks

## Test plan
- [x] All 43 tests pass
- [x] Verify enemies collapse and fade when killed
- [x] Verify kill detection, XP, and kill feed still work correctly

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)