### PR TITLE
#100 Add lava hazard zones and HUD warning indicator

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -289,13 +289,27 @@ class GameEngine {
         // Update doors (proximity-based opening + animation)
         this.map.updateDoors(this.player.x, this.player.y, deltaTime);
 
-        // Acid pool damage (5 HP/sec for player and enemies)
-        if (this.map.isAcidAtPosition(this.player.x, this.player.y)) {
+        // Hazard zone damage (acid: 5 HP/sec, lava: 8 HP/sec)
+        const inAcid = this.map.isAcidAtPosition(this.player.x, this.player.y);
+        const inLava = this.map.isLavaAtPosition(this.player.x, this.player.y);
+        if (inAcid) {
             if (!this._lastAcidTick || Date.now() - this._lastAcidTick > 500) {
                 this.player.takeDamage(2.5); // 2.5 per tick = 5/sec
                 if (this.hud) this.hud.onPlayerDamage();
                 this._lastAcidTick = Date.now();
             }
+        }
+        if (inLava) {
+            if (!this._lastLavaTick || Date.now() - this._lastLavaTick > 500) {
+                this.player.takeDamage(4); // 4 per tick = 8/sec
+                if (this.hud) this.hud.onPlayerDamage();
+                this._lastLavaTick = Date.now();
+            }
+        }
+        // Update HUD hazard warning
+        if (this.hud) {
+            this.hud.inHazardZone = inAcid || inLava;
+            this.hud.hazardType = inLava ? 'lava' : (inAcid ? 'acid' : null);
         }
         this.map.enemies.forEach(enemy => {
             if (!enemy.active || enemy.dying) return;

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -61,10 +61,12 @@ class Renderer {
     }
     
     buildAcidLookup() {
+        // Hazard lookup: 0=none, 1=acid, 2=lava
         this._acidLookup = [];
         for (let y = 0; y < this.map.height; y++) {
             this._acidLookup[y] = new Uint8Array(this.map.width);
         }
+        this._acidTileCount = 0;
         if (this.map.acidTiles) {
             for (const key of this.map.acidTiles) {
                 const [x, y] = key.split(',').map(Number);
@@ -72,9 +74,16 @@ class Renderer {
                     this._acidLookup[y][x] = 1;
                 }
             }
-            this._acidTileCount = this.map.acidTiles.size;
-        } else {
-            this._acidTileCount = 0;
+            this._acidTileCount += this.map.acidTiles.size;
+        }
+        if (this.map.lavaTiles) {
+            for (const key of this.map.lavaTiles) {
+                const [x, y] = key.split(',').map(Number);
+                if (y >= 0 && y < this.map.height && x >= 0 && x < this.map.width) {
+                    this._acidLookup[y][x] = 2;
+                }
+            }
+            this._acidTileCount += this.map.lavaTiles.size;
         }
     }
 
@@ -85,12 +94,27 @@ class Renderer {
         return false;
     }
 
+    isLavaTile(mapX, mapY) {
+        if (mapY >= 0 && mapY < this.map.height && mapX >= 0 && mapX < this.map.width) {
+            return this._acidLookup[mapY][mapX] === 2;
+        }
+        return false;
+    }
+
+    isHazardTile(mapX, mapY) {
+        if (mapY >= 0 && mapY < this.map.height && mapX >= 0 && mapX < this.map.width) {
+            return this._acidLookup[mapY][mapX] > 0;
+        }
+        return false;
+    }
+
     render(player) {
         // Clear screen
         this.clearScreen();
 
-        // Build acid tile lookup (once, or when tiles change)
-        if (!this._acidLookup || (this.map.acidTiles && this.map.acidTiles.size !== this._acidTileCount)) {
+        // Build hazard tile lookup (once, or when tiles change)
+        const totalHazardCount = (this.map.acidTiles ? this.map.acidTiles.size : 0) + (this.map.lavaTiles ? this.map.lavaTiles.size : 0);
+        if (!this._acidLookup || totalHazardCount !== this._acidTileCount) {
             this.buildAcidLookup();
         }
 
@@ -261,13 +285,21 @@ class Renderer {
                 const floorWorldY = player.y + actualDist * sinAngle;
                 const mapX = Math.floor(floorWorldX / this.wallHeight);
                 const mapY = Math.floor(floorWorldY / this.wallHeight);
-                if (this.isAcidTile(mapX, mapY)) {
+                const hazardType = this._acidLookup[mapY] && this._acidLookup[mapY][mapX];
+                if (hazardType > 0) {
                     const shade = Math.max(0.3, 1 - (rowDist / this.maxRenderDistance));
                     const pulse = 0.85 + 0.15 * Math.sin(this._acidTime + mapX * 3.7 + mapY * 5.3);
                     const s = shade * pulse;
-                    const r = Math.floor(15 * s);
-                    const g = Math.floor(180 * s);
-                    const b = Math.floor(10 * s);
+                    let r, g, b;
+                    if (hazardType === 2) { // Lava: orange
+                        r = Math.floor(220 * s);
+                        g = Math.floor(80 * s);
+                        b = Math.floor(10 * s);
+                    } else { // Acid: green
+                        r = Math.floor(15 * s);
+                        g = Math.floor(180 * s);
+                        b = Math.floor(10 * s);
+                    }
                     this.setPixel(x, y, 0xFF000000 | (b << 16) | (g << 8) | r);
                 } else {
                     this.setPixel(x, y, baseFloorColor);
@@ -279,7 +311,7 @@ class Renderer {
             }
         }
     }
-    
+
     renderFloorCeiling(x, player, rayAngle) {
         for (let y = 0; y < this.halfHeight; y++) {
             this.setPixel(x, y, this.hexToRgb(this.ceilingColor));
@@ -297,13 +329,21 @@ class Renderer {
                 const floorWorldY = player.y + actualDist * sinAngle;
                 const mapX = Math.floor(floorWorldX / this.wallHeight);
                 const mapY = Math.floor(floorWorldY / this.wallHeight);
-                if (this.isAcidTile(mapX, mapY)) {
+                const hazardType = this._acidLookup[mapY] && this._acidLookup[mapY][mapX];
+                if (hazardType > 0) {
                     const shade = Math.max(0.3, 1 - (rowDist / this.maxRenderDistance));
                     const pulse = 0.85 + 0.15 * Math.sin(this._acidTime + mapX * 3.7 + mapY * 5.3);
                     const s = shade * pulse;
-                    const r = Math.floor(15 * s);
-                    const g = Math.floor(180 * s);
-                    const b = Math.floor(10 * s);
+                    let r, g, b;
+                    if (hazardType === 2) { // Lava: orange
+                        r = Math.floor(220 * s);
+                        g = Math.floor(80 * s);
+                        b = Math.floor(10 * s);
+                    } else { // Acid: green
+                        r = Math.floor(15 * s);
+                        g = Math.floor(180 * s);
+                        b = Math.floor(10 * s);
+                    }
                     this.setPixel(x, y, 0xFF000000 | (b << 16) | (g << 8) | r);
                 } else {
                     this.setPixel(x, y, baseFloorColor);

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -59,6 +59,10 @@ class HUD {
         this.revealedTiles = new Set();
         this.fogRevealRadius = 4; // tiles
 
+        // Hazard zone warning
+        this.inHazardZone = false;
+        this.hazardType = null; // 'acid' or 'lava'
+
         // Load weapon sprite images (from FPS Starter Kit, CC0)
         this.weaponImages = {};
         this.loadWeaponImages();
@@ -145,6 +149,9 @@ class HUD {
 
             // Render damage flash effect
             this.renderDamageFlash(player);
+
+            // Render hazard zone warning
+            this.renderHazardWarning();
 
             this.ctx.restore();
         } catch (error) {
@@ -675,6 +682,35 @@ class HUD {
         }
     }
     
+    renderHazardWarning() {
+        if (!this.inHazardZone) return;
+
+        const now = Date.now();
+        const w = this.canvas.width;
+        const h = this.canvas.height;
+        const pulse = 0.15 + 0.1 * Math.sin(now * 0.008);
+
+        // Screen edge tint (green for acid, orange for lava)
+        const color = this.hazardType === 'lava' ? '255, 100, 0' : '0, 200, 0';
+        const edgeSize = 40;
+
+        // Bottom edge warning glow
+        const grad = this.ctx.createLinearGradient(0, h, 0, h - edgeSize);
+        grad.addColorStop(0, `rgba(${color}, ${pulse})`);
+        grad.addColorStop(1, `rgba(${color}, 0)`);
+        this.ctx.fillStyle = grad;
+        this.ctx.fillRect(0, h - edgeSize, w, edgeSize);
+
+        // Warning text
+        const label = this.hazardType === 'lava' ? 'LAVA' : 'TOXIC';
+        this.ctx.font = 'bold 14px monospace';
+        this.ctx.textAlign = 'center';
+        const textAlpha = 0.6 + 0.4 * Math.sin(now * 0.006);
+        this.ctx.fillStyle = `rgba(${color}, ${textAlpha})`;
+        this.ctx.fillText(`WARNING: ${label} ZONE`, w / 2, h - 52);
+        this.ctx.textAlign = 'left';
+    }
+
     renderDamageIndicators(player) {
         const now = Date.now();
         const w = this.canvas.width;
@@ -1162,6 +1198,21 @@ class HUD {
                 this.ctx.fillRect(
                     mapX + ax * cellW,
                     mapY + ay * cellH,
+                    Math.ceil(cellW),
+                    Math.ceil(cellH)
+                );
+            }
+        }
+
+        // Draw lava tiles (only in revealed areas)
+        if (map.lavaTiles) {
+            this.ctx.fillStyle = 'rgba(255, 100, 0, 0.4)';
+            for (const key of map.lavaTiles) {
+                const [lx, ly] = key.split(',').map(Number);
+                if (!this.isTileRevealed(lx, ly)) continue;
+                this.ctx.fillRect(
+                    mapX + lx * cellW,
+                    mapY + ly * cellH,
                     Math.ceil(cellW),
                     Math.ceil(cellH)
                 );

--- a/js/world/map.js
+++ b/js/world/map.js
@@ -49,6 +49,7 @@ class GameMap {
         this.doors = []; // Interactive doors
         this.barrels = []; // Exploding barrels
         this.acidTiles = new Set(); // Floor tiles that deal acid damage
+        this.lavaTiles = new Set(); // Floor tiles that deal lava/fire damage
 
         // Door system
         this.initializeDoors();
@@ -113,6 +114,14 @@ class GameMap {
         // Cooling tunnel leak
         this.addAcidTile(2, 11);
         this.addAcidTile(4, 14);
+
+        // Lava vents — orange-tinted floor tiles that deal 8 HP/sec
+        // Reactor Core center vents
+        this.addLavaTile(12, 12);
+        this.addLavaTile(11, 11);
+        // South-east wing heat vents
+        this.addLavaTile(20, 19);
+        this.addLavaTile(21, 20);
 
         // Exploding barrels — shoot to detonate (60 dmg, 100 unit radius)
         // Main corridor
@@ -283,6 +292,24 @@ class GameMap {
         const mapX = Math.floor(worldX / this.tileSize);
         const mapY = Math.floor(worldY / this.tileSize);
         return this.isAcidTile(mapX, mapY);
+    }
+
+    addLavaTile(mapX, mapY) {
+        this.lavaTiles.add(mapX + ',' + mapY);
+    }
+
+    isLavaTile(mapX, mapY) {
+        return this.lavaTiles.has(mapX + ',' + mapY);
+    }
+
+    isLavaAtPosition(worldX, worldY) {
+        const mapX = Math.floor(worldX / this.tileSize);
+        const mapY = Math.floor(worldY / this.tileSize);
+        return this.isLavaTile(mapX, mapY);
+    }
+
+    isHazardAtPosition(worldX, worldY) {
+        return this.isAcidAtPosition(worldX, worldY) || this.isLavaAtPosition(worldX, worldY);
     }
 
     addBarrel(x, y) {


### PR DESCRIPTION
## Summary
- Adds lava as a second hazard type (orange, 8 HP/sec) alongside existing acid tiles (green, 5 HP/sec)
- 4 lava tiles placed in reactor core and south-east wing areas
- HUD shows pulsing "WARNING: LAVA ZONE" / "WARNING: TOXIC ZONE" text with colored bottom-edge glow
- Lava tiles render on minimap in orange
- Renderer supports both hazard types via unified lookup table

## Test plan
- [x] All 43 tests pass
- [x] Verify lava tiles render as orange pulsing floor
- [x] Verify HUD warning appears when standing in hazard zones
- [x] Verify acid tiles still work as before

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)