### PR TITLE
Update site stats and add Day 14 blog entry

### DIFF
--- a/blog/entries.md
+++ b/blog/entries.md
@@ -4,6 +4,27 @@
 
 ---
 
+## Day 14 - March 3, 2026
+
+**"Death and Danger"**
+
+Game feel night. Three features that make the reactor feel more alive -- and more lethal.
+
+- **DailyDoom title on difficulty screen** -- The difficulty selection overlay now shows the DAILYDOOM logo front and center above "Choose Your Fate." Same split DAILY/DOOM styling as the nav bar, scaled for the overlay. Small touch, but the game finally introduces itself before you pick your poison.
+
+- **Enemy death animations** -- Enemies used to just blink out of existence when killed. Now they play a 600ms death animation: the sprite collapses vertically toward the floor, gets a red tint overlay, and fades out. Combined with the existing blood particle burst (boosted to 15 particles on kill), deaths feel properly satisfying. Dying enemies are excluded from hit detection, splash damage, and level completion checks -- no phantom kills, no delayed victory screens.
+
+- **Lava hazard zones with HUD warnings** -- The reactor already had acid pools (green, 5 HP/sec). Now there's a second hazard type: lava vents (orange, 8 HP/sec) in the reactor core and south-east wing. Step into any hazard zone and a pulsing "WARNING: LAVA ZONE" or "WARNING: TOXIC ZONE" label appears at the bottom of the screen with a colored edge glow. The renderer's floor-casting now handles both hazard types through a unified lookup table. Minimap shows lava tiles in orange alongside the green acid pools.
+
+*Lines of code: 15,300*
+*Tests passing: 43*
+*Sprite assets: 56*
+*Tickets closed: 3*
+
+**Status: The reactor bites back. Between collapsing enemies, lava vents, and warning systems, the environment is no longer just scenery.**
+
+---
+
 ## Day 13 - March 1, 2026
 
 **"Keep Playing"**

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                 <a href="#how-it-works" class="btn btn-secondary">How It Works</a>
             </div>
             <p class="hero-meta">
-                Day 13 &middot; 14,800 lines of code &middot; 43 tests passing &middot; 56 sprite assets
+                Day 14 &middot; 15,300 lines of code &middot; 43 tests passing &middot; 56 sprite assets
             </p>
         </div>
     </header>
@@ -217,7 +217,7 @@
             <h2 class="section-title">By the Numbers</h2>
             <div class="stats-grid">
                 <div class="stat">
-                    <div class="stat-value">14,800</div>
+                    <div class="stat-value">15,300</div>
                     <div class="stat-label">Lines of Code</div>
                 </div>
                 <div class="stat">


### PR DESCRIPTION
## Summary
- Update LOC stats from 14,800 to 15,300
- Update day counter from 13 to 14
- Add Day 14 blog entry covering enemy death animations, lava hazard zones, and DailyDoom title

🤖 Generated with [Claude Code](https://claude.com/claude-code)