### PR TITLE
Add enemy projectile system for ranged attackers

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,6 +279,7 @@
     <script src="js/entities/player.js"></script>
     <script src="js/entities/enemy.js"></script>
     <script src="js/entities/enemy-behaviors.js"></script>
+    <script src="js/entities/projectile.js"></script>
     <script src="js/entities/pickup.js"></script>
     <script src="js/weapons/weapon.js"></script>
     <script src="js/audio/sound-engine.js"></script>

--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -91,6 +91,10 @@ class GameEngine {
         this.pickupManager.spawnRandomPickups(this.map, 6);
         this.pickupManager.spawnModPickups(this.map);
         console.log('Pickup system initialized');
+
+        // Initialize projectile system
+        this.projectileManager = new ProjectileManager();
+        console.log('Projectile system initialized');
         
         // Bind debug toggle
         this.bindDebugToggle();
@@ -195,6 +199,7 @@ class GameEngine {
         this.pickupManager.spawnWeaponPickups(this.map);
         this.pickupManager.spawnRandomPickups(this.map, 6);
         this.pickupManager.spawnModPickups(this.map);
+        this.projectileManager.clear();
         this.hud.resetFog();
         this.levelStartTime = performance.now();
         this.totalEnemyCount = this.map.enemies.length;
@@ -285,6 +290,9 @@ class GameEngine {
 
         // Update pickups
         this.pickupManager.update(deltaTime, this.player);
+
+        // Update projectiles
+        this.projectileManager.update(deltaTime, this.map, this.player);
 
         // Update doors (proximity-based opening + animation)
         this.map.updateDoors(this.player.x, this.player.y, deltaTime);
@@ -522,6 +530,9 @@ class GameEngine {
         this.pickupManager.spawnWeaponPickups(this.map);
         this.pickupManager.spawnRandomPickups(this.map, 6);
         this.pickupManager.spawnModPickups(this.map);
+
+        // Clear projectiles
+        this.projectileManager.clear();
 
         // Re-apply difficulty
         if (window.CONFIG && window.CONFIG.difficulty) {

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -834,9 +834,34 @@ class Renderer {
             });
         }
 
+        // Add projectiles to rendering queue
+        if (window.game && window.game.projectileManager) {
+            window.game.projectileManager.getActiveProjectiles().forEach(proj => {
+                const dx = proj.x - player.x;
+                const dy = proj.y - player.y;
+                const distance = Math.sqrt(dx * dx + dy * dy);
+                if (distance > this.maxRenderDistance) return;
+
+                let projAngle = Math.atan2(dy, dx);
+                let angleDiff = projAngle - player.angle;
+                while (angleDiff > Math.PI) angleDiff -= MathUtils.PI2;
+                while (angleDiff < -Math.PI) angleDiff += MathUtils.PI2;
+                if (Math.abs(angleDiff) > this.fov / 2) return;
+
+                spritesToRender.push({
+                    entity: proj,
+                    entityType: 'projectile',
+                    distance: distance,
+                    angleDiff: angleDiff,
+                    x: proj.x,
+                    y: proj.y
+                });
+            });
+        }
+
         // Sort sprites by distance (furthest first)
         spritesToRender.sort((a, b) => b.distance - a.distance);
-        
+
         // Render each sprite
         spritesToRender.forEach(spriteData => {
             this.renderSprite(spriteData, player);
@@ -974,6 +999,24 @@ class Renderer {
                 this.ctx.lineWidth = 2;
                 this.ctx.stroke();
             }
+        } else if (entityType === 'projectile') {
+            const size = Math.max(4, (this.wallHeight * this.projectionDistance) / distance * 0.08);
+            const wallScreenHeight = (this.wallHeight * this.projectionDistance) / distance;
+            const floorY = this.halfHeight + wallScreenHeight / 2;
+            // Center projectile vertically at half-wall height
+            const projY = this.halfHeight;
+
+            // Glowing projectile circle
+            this.ctx.fillStyle = entity.color || '#FF4400';
+            this.ctx.beginPath();
+            this.ctx.arc(screenX, projY, size, 0, Math.PI * 2);
+            this.ctx.fill();
+
+            // Bright core
+            this.ctx.fillStyle = '#FFFFFF';
+            this.ctx.beginPath();
+            this.ctx.arc(screenX, projY, size * 0.4, 0, Math.PI * 2);
+            this.ctx.fill();
         } else if (entityType === 'barrel') {
             const size = (this.wallHeight * this.projectionDistance) / distance * 0.35;
             const wallScreenHeight = (this.wallHeight * this.projectionDistance) / distance;

--- a/js/entities/enemy-behaviors.js
+++ b/js/entities/enemy-behaviors.js
@@ -557,6 +557,24 @@ class EnhancedEnemyAI {
                 damage = Math.round(damage * 2);
             }
 
+            // Ranged enemies fire projectiles instead of hitscan
+            if (this.behavior.rangedAttack || this.behavior.strafeBehavior) {
+                if (window.game && window.game.projectileManager) {
+                    const speed = this.behavior.rangedAttack ? 150 : 200;
+                    const color = this.behavior.rangedAttack ? '#44FF44' : '#FFAA00';
+                    window.game.projectileManager.spawn(
+                        this.enemy.x, this.enemy.y,
+                        player.x, player.y,
+                        damage, speed, color, this.enemy
+                    );
+                    // Play projectile fire sound
+                    if (window.soundEngine && window.soundEngine.isInitialized) {
+                        this.playAttackSound();
+                    }
+                }
+                return;
+            }
+
             // Deal damage to player (with invincibility frame check)
             if (player.takeDamage(damage)) {
                 // Trigger HUD damage flash

--- a/js/entities/projectile.js
+++ b/js/entities/projectile.js
@@ -1,0 +1,100 @@
+/**
+ * Projectile System - Enemy projectiles that travel through the world
+ */
+class Projectile {
+    constructor(x, y, targetX, targetY, damage, speed, color, owner) {
+        this.x = x;
+        this.y = y;
+        this.damage = damage;
+        this.speed = speed;
+        this.color = color || '#FF4400';
+        this.owner = owner; // Reference to the enemy that fired it
+        this.active = true;
+        this.radius = 6;
+        this.lifetime = 5000; // Max 5 seconds
+        this.spawnTime = Date.now();
+
+        // Calculate velocity toward target
+        const dx = targetX - x;
+        const dy = targetY - y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist > 0) {
+            this.velX = (dx / dist) * speed;
+            this.velY = (dy / dist) * speed;
+        } else {
+            this.velX = 0;
+            this.velY = 0;
+        }
+    }
+
+    update(deltaTime, map, player) {
+        if (!this.active) return;
+
+        // Check lifetime
+        if (Date.now() - this.spawnTime > this.lifetime) {
+            this.active = false;
+            return;
+        }
+
+        // Move projectile
+        const newX = this.x + this.velX * deltaTime;
+        const newY = this.y + this.velY * deltaTime;
+
+        // Check wall collision
+        if (map.isWallAtPosition(newX, newY)) {
+            this.active = false;
+            return;
+        }
+
+        this.x = newX;
+        this.y = newY;
+
+        // Check player collision
+        const dx = this.x - player.x;
+        const dy = this.y - player.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < player.radius + this.radius) {
+            if (player.takeDamage(this.damage)) {
+                // Trigger HUD damage flash from projectile direction
+                if (window.game && window.game.hud) {
+                    window.game.hud.onPlayerDamageFrom(this.x, this.y);
+                }
+                if (window.soundEngine && window.soundEngine.isInitialized) {
+                    window.soundEngine.playPlayerHit();
+                }
+            }
+            this.active = false;
+        }
+    }
+}
+
+class ProjectileManager {
+    constructor() {
+        this.projectiles = [];
+    }
+
+    spawn(x, y, targetX, targetY, damage, speed, color, owner) {
+        this.projectiles.push(new Projectile(x, y, targetX, targetY, damage, speed, color, owner));
+    }
+
+    update(deltaTime, map, player) {
+        for (let i = this.projectiles.length - 1; i >= 0; i--) {
+            this.projectiles[i].update(deltaTime, map, player);
+            if (!this.projectiles[i].active) {
+                this.projectiles.splice(i, 1);
+            }
+        }
+    }
+
+    getActiveProjectiles() {
+        return this.projectiles;
+    }
+
+    clear() {
+        this.projectiles = [];
+    }
+}
+
+// Export to global scope
+window.Projectile = Projectile;
+window.ProjectileManager = ProjectileManager;


### PR DESCRIPTION
## Summary
- Soldier and Spitter enemies now fire visible projectiles instead of instant hitscan damage
- Projectiles travel at defined speeds (150-200 units/sec), collide with walls and the player
- Projectiles rendered as glowing colored orbs (green for spitter, orange for soldier) in the raycasting view
- New `ProjectileManager` integrated into the game loop with proper cleanup on restart

## Test plan
- [x] All 43 existing tests pass
- [x] Projectile class handles position, velocity, collision, and lifetime
- [x] Soldier/Spitter fire projectiles; other enemy types still use melee/hitscan

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)