### PR TITLE
Add destructible crates with item drops

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -828,6 +828,45 @@ class SoundEngine {
     }
 
     // Barrel explosion
+    playCrateBreak() {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Short cracking/breaking noise
+        const noiseBuffer = this.createNoiseBuffer(0.15);
+        if (noiseBuffer) {
+            const noise = this.audioContext.createBufferSource();
+            noise.buffer = noiseBuffer;
+            const noiseGain = this.audioContext.createGain();
+            const filter = this.audioContext.createBiquadFilter();
+            filter.type = 'bandpass';
+            filter.frequency.setValueAtTime(800, now);
+            filter.Q.setValueAtTime(2, now);
+            noise.connect(filter);
+            filter.connect(noiseGain);
+            noiseGain.connect(this.masterGain);
+            noiseGain.gain.setValueAtTime(0, now);
+            noiseGain.gain.linearRampToValueAtTime(this.sfxVolume * 0.4, now + 0.01);
+            noiseGain.gain.exponentialRampToValueAtTime(0.001, now + 0.15);
+            noise.start(now);
+            noise.stop(now + 0.15);
+        }
+
+        // Low thud
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(120, now);
+        osc.frequency.exponentialRampToValueAtTime(40, now + 0.1);
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.3, now + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.12);
+        osc.start(now);
+        osc.stop(now + 0.12);
+    }
+
     playExplosion() {
         if (!this.isInitialized) return;
         const now = this.audioContext.currentTime;

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -834,6 +834,33 @@ class Renderer {
             });
         }
 
+        // Add crates to rendering queue
+        if (this.map.crates) {
+            this.map.crates.forEach(crate => {
+                if (!crate.active) return;
+                const dx = crate.x - player.x;
+                const dy = crate.y - player.y;
+                const distance = Math.sqrt(dx * dx + dy * dy);
+                if (distance > this.maxRenderDistance) return;
+
+                let crateAngle = Math.atan2(dy, dx);
+                let angleDiff = crateAngle - player.angle;
+                while (angleDiff > Math.PI) angleDiff -= MathUtils.PI2;
+                while (angleDiff < -Math.PI) angleDiff += MathUtils.PI2;
+                if (Math.abs(angleDiff) > this.fov / 2) return;
+                if (this.isOccludedByWall(player.x, player.y, crate.x, crate.y)) return;
+
+                spritesToRender.push({
+                    entity: crate,
+                    entityType: 'crate',
+                    distance: distance,
+                    angleDiff: angleDiff,
+                    x: crate.x,
+                    y: crate.y
+                });
+            });
+        }
+
         // Add projectiles to rendering queue
         if (window.game && window.game.projectileManager) {
             window.game.projectileManager.getActiveProjectiles().forEach(proj => {
@@ -998,6 +1025,45 @@ class Renderer {
                 this.ctx.strokeStyle = '#FFFFFF';
                 this.ctx.lineWidth = 2;
                 this.ctx.stroke();
+            }
+        } else if (entityType === 'crate') {
+            const size = (this.wallHeight * this.projectionDistance) / distance * 0.35;
+            const wallScreenHeight = (this.wallHeight * this.projectionDistance) / distance;
+            const floorY = this.halfHeight + wallScreenHeight / 2;
+            const crateX = screenX - size / 2;
+            const crateY = floorY - size;
+
+            // Wooden crate body
+            this.ctx.fillStyle = '#8B6914';
+            this.ctx.fillRect(crateX, crateY, size, size);
+
+            // Darker planks
+            this.ctx.fillStyle = '#6B4F10';
+            this.ctx.fillRect(crateX, crateY + size * 0.48, size, size * 0.04);
+            this.ctx.fillRect(crateX + size * 0.48, crateY, size * 0.04, size);
+
+            // Cross bracing
+            this.ctx.strokeStyle = '#5A3E0D';
+            this.ctx.lineWidth = Math.max(1, size * 0.03);
+            this.ctx.beginPath();
+            this.ctx.moveTo(crateX + size * 0.1, crateY + size * 0.1);
+            this.ctx.lineTo(crateX + size * 0.9, crateY + size * 0.9);
+            this.ctx.moveTo(crateX + size * 0.9, crateY + size * 0.1);
+            this.ctx.lineTo(crateX + size * 0.1, crateY + size * 0.9);
+            this.ctx.stroke();
+
+            // Border
+            this.ctx.strokeStyle = '#4A2E08';
+            this.ctx.lineWidth = 1;
+            this.ctx.strokeRect(crateX, crateY, size, size);
+
+            // Health indicator (darken as damaged)
+            const healthPct = entity.health / entity.maxHealth;
+            if (healthPct < 1) {
+                this.ctx.globalAlpha = (1 - healthPct) * 0.4;
+                this.ctx.fillStyle = '#000000';
+                this.ctx.fillRect(crateX, crateY, size, size);
+                this.ctx.globalAlpha = 1.0;
             }
         } else if (entityType === 'projectile') {
             const size = Math.max(4, (this.wallHeight * this.projectionDistance) / distance * 0.08);

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -201,7 +201,15 @@ class Weapon {
             }
         }
 
-        if (!hit.enemy && !hit.barrel && hit.hitWall) {
+        // Crate hit — damage crate, destroy and drop item if broken
+        if (hit.crate && hit.crate.active) {
+            hit.crate.health -= this.damage;
+            if (hit.crate.health <= 0) {
+                map.destroyCrate(hit.crate);
+            }
+        }
+
+        if (!hit.enemy && !hit.barrel && !hit.crate && hit.hitWall) {
             // Wall impact effect
             if (window.game && window.game.hud) {
                 window.game.hud.addImpactSpark(hit.hitPoint.x, hit.hitPoint.y);
@@ -329,9 +337,33 @@ class Weapon {
             }
         }
 
+        // Check for crate collisions
+        let closestCrate = null;
+        let closestCrateDistance = this.range;
+        if (map.crates) {
+            let cCheckX = rayX, cCheckY = rayY, cDist = 0;
+            const cStepSize = 2;
+            while (cDist < this.range) {
+                cCheckX += rayDirX * cStepSize;
+                cCheckY += rayDirY * cStepSize;
+                cDist += cStepSize;
+                if (map.isWallAtPosition(cCheckX, cCheckY)) break;
+                for (const crate of map.crates) {
+                    if (!crate.active) continue;
+                    const cdx = crate.x - cCheckX;
+                    const cdy = crate.y - cCheckY;
+                    if (Math.sqrt(cdx * cdx + cdy * cdy) < crate.radius && cDist < closestCrateDistance) {
+                        closestCrate = crate;
+                        closestCrateDistance = cDist;
+                    }
+                }
+            }
+        }
+
         return {
             enemy: closestEnemy,
             barrel: closestBarrel,
+            crate: closestCrate,
             distance: closestDistance,
             hitPoint: { x: currentX, y: currentY },
             hitWall: !closestEnemy && map.isWallAtPosition(currentX, currentY)

--- a/js/world/map.js
+++ b/js/world/map.js
@@ -48,6 +48,7 @@ class GameMap {
         this.enemies = []; // Enemy spawn points
         this.doors = []; // Interactive doors
         this.barrels = []; // Exploding barrels
+        this.crates = []; // Destructible crates with item drops
         this.acidTiles = new Set(); // Floor tiles that deal acid damage
         this.lavaTiles = new Set(); // Floor tiles that deal lava/fire damage
 
@@ -135,6 +136,24 @@ class GameMap {
         this.addBarrel(5.5 * this.tileSize, 16.5 * this.tileSize);
         // Near boss room
         this.addBarrel(17.5 * this.tileSize, 20.5 * this.tileSize);
+
+        // Destructible crates — shoot to break, drops random item
+        // Control room area
+        this.addCrate(5.5 * this.tileSize, 6.5 * this.tileSize);
+        // North corridor
+        this.addCrate(14.5 * this.tileSize, 1.5 * this.tileSize);
+        // Near cooling tunnels
+        this.addCrate(4.5 * this.tileSize, 11.5 * this.tileSize);
+        // Reactor area entrance
+        this.addCrate(8.5 * this.tileSize, 10.5 * this.tileSize);
+        // South corridor
+        this.addCrate(10.5 * this.tileSize, 16.5 * this.tileSize);
+        // Containment wing
+        this.addCrate(20.5 * this.tileSize, 4.5 * this.tileSize);
+        // Waste storage
+        this.addCrate(3.5 * this.tileSize, 21.5 * this.tileSize);
+        // South-east wing
+        this.addCrate(20.5 * this.tileSize, 21.5 * this.tileSize);
     }
 
     initializeDoors() {
@@ -377,6 +396,42 @@ class GameMap {
                 setTimeout(() => this.explodeBarrel(other), 150);
             }
         });
+    }
+
+    addCrate(x, y) {
+        this.crates.push({
+            x, y,
+            health: 40,
+            maxHealth: 40,
+            active: true,
+            radius: 16
+        });
+    }
+
+    destroyCrate(crate) {
+        if (!crate.active) return;
+        crate.active = false;
+
+        // Particle burst
+        if (window.game && window.game.hud) {
+            window.game.hud.emitExplosionParticles(crate.x, crate.y, 8);
+        }
+
+        // Play crate break sound
+        if (window.soundEngine && window.soundEngine.isInitialized) {
+            window.soundEngine.playCrateBreak();
+        }
+
+        // Drop a random pickup
+        if (window.game && window.game.pickupManager) {
+            const dropTypes = ['health', 'ammo_pistol', 'ammo_shotgun', 'ammo_rifle', 'ammo_rocket', 'armor'];
+            const dropType = dropTypes[Math.floor(Math.random() * dropTypes.length)];
+            window.game.pickupManager.addPickup(crate.x, crate.y, dropType);
+
+            if (window.game.hud && window.game.hud.addKillFeedMessage) {
+                window.game.hud.addKillFeedMessage('Crate destroyed!', '#C8A030');
+            }
+        }
     }
 
     // Check if a coordinate contains a wall (for entity collision)


### PR DESCRIPTION
## Summary
- 8 wooden crates placed throughout the map in strategic locations
- Crates can be shot and destroyed, spawning a random pickup (health, ammo, or armor)
- Visual particle burst and procedural break sound on destruction
- Kill feed notification when crate is destroyed
- Crates rendered as wooden boxes with cross-bracing and damage darkening

## Test plan
- [x] All 43 existing tests pass
- [x] Crate raycast detection works in weapon system
- [x] Crate destruction spawns pickup items

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)