### PR TITLE
Add secret rooms behind destructible walls

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -1069,6 +1069,45 @@ class SoundEngine {
         osc.stop(now + 0.12);
     }
 
+    playWallBreak() {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Heavy crumbling noise (longer and deeper than crate)
+        const noiseBuffer = this.createNoiseBuffer(0.4);
+        if (noiseBuffer) {
+            const noise = this.audioContext.createBufferSource();
+            noise.buffer = noiseBuffer;
+            const noiseGain = this.audioContext.createGain();
+            const filter = this.audioContext.createBiquadFilter();
+            filter.type = 'lowpass';
+            filter.frequency.setValueAtTime(600, now);
+            filter.frequency.exponentialRampToValueAtTime(200, now + 0.3);
+            noise.connect(filter);
+            filter.connect(noiseGain);
+            noiseGain.connect(this.masterGain);
+            noiseGain.gain.setValueAtTime(0, now);
+            noiseGain.gain.linearRampToValueAtTime(this.sfxVolume * 0.6, now + 0.02);
+            noiseGain.gain.exponentialRampToValueAtTime(0.001, now + 0.4);
+            noise.start(now);
+            noise.stop(now + 0.4);
+        }
+
+        // Deep impact thud
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(80, now);
+        osc.frequency.exponentialRampToValueAtTime(25, now + 0.25);
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.5, now + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+        osc.start(now);
+        osc.stop(now + 0.3);
+    }
+
     playExplosion() {
         if (!this.isInitialized) return;
         const now = this.audioContext.currentTime;

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -44,7 +44,8 @@ class Renderer {
             6: '#00FFFF', // Cyan wall
             7: '#FFFFFF', // White wall
             8: '#888888', // Gray wall
-            9: '#8B4513'  // Door (brown/wood)
+            9: '#8B4513', // Door (brown/wood)
+            10: '#AA7733' // Cracked destructible wall
         };
         
         // Performance optimization
@@ -727,7 +728,8 @@ class Renderer {
             6: 'stone',    // Purple areas (fallback to stone)
             7: 'metal',    // Other areas
             8: 'brick',    // Fallback
-            9: 'tech'      // Doors
+            9: 'tech',     // Doors
+            10: 'brick'    // Cracked destructible walls
         };
     }
     

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -128,6 +128,11 @@ class HUD {
                 this.renderMinimap(player, gameEngine);
             }
 
+            // Render secrets counter
+            if (gameEngine && gameEngine.map && gameEngine.map.totalSecrets > 0) {
+                this.renderSecretsCounter(gameEngine.map);
+            }
+
             // Render kill feed
             this.renderKillFeed();
 
@@ -953,6 +958,21 @@ class HUD {
         this.ctx.fillText(`K:${kills}`, x + barWidth - 30, y + 10);
     }
 
+    renderSecretsCounter(map) {
+        const x = 20;
+        const y = this.canvas.height - 25;
+
+        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+        this.ctx.fillRect(x - 2, y - 12, 100, 18);
+
+        const found = map.secretsFound;
+        const total = map.totalSecrets;
+        this.ctx.fillStyle = found === total ? '#FFD700' : '#AAAAAA';
+        this.ctx.font = this.smallFont;
+        this.ctx.textAlign = 'left';
+        this.ctx.fillText(`SECRETS: ${found}/${total}`, x, y);
+    }
+
     // Kill feed system
     addKillFeedMessage(text, color = '#FF4444') {
         this.killFeed.unshift({
@@ -1177,6 +1197,7 @@ class HUD {
                         case 5: this.ctx.fillStyle = '#888866'; break;
                         case 6: this.ctx.fillStyle = '#666644'; break;
                         case 9: this.ctx.fillStyle = '#886600'; break;
+                        case 10: this.ctx.fillStyle = '#AA7733'; break;
                         default: this.ctx.fillStyle = '#444444'; break;
                     }
                     this.ctx.fillRect(

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -209,6 +209,11 @@ class Weapon {
             }
         }
 
+        // Secret wall hit — damage destructible wall
+        if (hit.secretWall) {
+            map.damageSecretWall(hit.secretWall.mapX, hit.secretWall.mapY, this.damage);
+        }
+
         if (!hit.enemy && !hit.barrel && !hit.crate && hit.hitWall) {
             // Wall impact effect
             if (window.game && window.game.hud) {
@@ -360,10 +365,20 @@ class Weapon {
             }
         }
 
+        // Check if the ray hit a secret wall (destructible wall type 10)
+        let hitSecretWall = null;
+        if (map.isWallAtPosition(currentX, currentY)) {
+            const wallMapX = Math.floor(currentX / map.tileSize);
+            const wallMapY = Math.floor(currentY / map.tileSize);
+            const sw = map.getSecretWallAt(wallMapX, wallMapY);
+            if (sw) hitSecretWall = sw;
+        }
+
         return {
             enemy: closestEnemy,
             barrel: closestBarrel,
             crate: closestCrate,
+            secretWall: hitSecretWall,
             distance: closestDistance,
             hitPoint: { x: currentX, y: currentY },
             hitWall: !closestEnemy && map.isWallAtPosition(currentX, currentY)

--- a/js/world/map.js
+++ b/js/world/map.js
@@ -14,12 +14,13 @@ class GameMap {
         this.spawnAngle = 0;
 
         // Wall types: 1=stone(outer), 2=brick(containment), 3=metal(cooling),
-        // 4=tech(control room), 5=marble(reactor core), 6=stone(waste storage)
+        // 4=tech(control room), 5=marble(reactor core), 6=stone(waste storage),
+        // 10=cracked(destructible secret wall)
         this.grid = [
         //   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
             [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1], // 0  outer wall
-            [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1], // 1  north corridor
-            [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1], // 2  north corridor
+            [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,1,0,0,0,0,0,1], // 1  north corridor (secret at 16,1)
+            [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,10,0,0,0,0,0,0,1], // 2  cracked wall at (16,2)
             [1,0,0,4,4,4,4,0,0,1,1,1,0,1,1,0,0,0,2,2,2,2,0,1], // 3  control room top / containment top
             [1,0,0,4,0,0,4,0,0,0,0,0,0,0,0,0,0,0,2,0,0,2,0,1], // 4  control room interior
             [1,0,0,4,0,0,4,4,0,0,0,0,0,0,0,0,0,0,2,0,0,2,0,1], // 5  control room (wall at col 7)
@@ -33,8 +34,8 @@ class GameMap {
             [1,0,0,3,0,0,3,0,0,5,0,0,0,0,0,5,0,0,3,0,0,0,3,1], // 13 cooling / reactor interior
             [1,0,0,3,0,0,3,0,0,5,0,0,0,0,0,5,0,0,3,0,0,0,3,1], // 14 cooling / reactor interior
             [1,3,3,3,0,3,3,0,0,5,5,5,0,5,5,5,0,0,3,3,0,3,3,1], // 15 cooling tunnels / reactor bottom
-            [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1], // 16 south corridor
-            [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1], // 17 south corridor
+            [1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,1], // 16 south corridor (secrets at 1,16 and 22,16)
+            [1,10,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,10,1], // 17 cracked walls at (1,17) and (22,17)
             [1,6,6,6,6,6,6,0,0,1,1,1,0,1,1,1,0,0,1,1,1,1,1,1], // 18 waste storage top / south rooms
             [1,6,0,0,0,0,6,0,0,1,0,0,0,0,0,1,0,0,1,0,0,0,0,1], // 19 waste storage
             [1,6,0,0,0,0,6,0,0,1,0,0,0,0,0,1,0,0,1,0,0,0,0,1], // 20 waste storage
@@ -51,12 +52,18 @@ class GameMap {
         this.crates = []; // Destructible crates with item drops
         this.acidTiles = new Set(); // Floor tiles that deal acid damage
         this.lavaTiles = new Set(); // Floor tiles that deal lava/fire damage
+        this.secretWalls = []; // Destructible secret walls
+        this.secretsFound = 0;
+        this.totalSecrets = 0;
 
         // Door system
         this.initializeDoors();
 
         // Initialize additional map elements
         this.initializeMapElements();
+
+        // Initialize secret rooms
+        this.initializeSecretRooms();
         
         console.log('Map initialized:', this.width + 'x' + this.height);
     }
@@ -432,6 +439,106 @@ class GameMap {
                 window.game.hud.addKillFeedMessage('Crate destroyed!', '#C8A030');
             }
         }
+    }
+
+    // --- Secret Room methods ---
+
+    initializeSecretRooms() {
+        // Secret 1: North corridor — room at (16,1), cracked wall at (16,2)
+        this.addSecretWall(16, 2, 16, 1);
+        // Secret 2: SW south corridor — room at (1,16), cracked wall at (1,17)
+        this.addSecretWall(1, 17, 1, 16);
+        // Secret 3: SE south corridor — room at (22,16), cracked wall at (22,17)
+        this.addSecretWall(22, 17, 22, 16);
+
+        console.log(`Secret rooms initialized: ${this.totalSecrets} secrets`);
+    }
+
+    addSecretWall(mapX, mapY, roomX, roomY) {
+        this.secretWalls.push({
+            mapX, mapY,
+            roomX, roomY,
+            health: 80,
+            maxHealth: 80,
+            active: true
+        });
+        this.totalSecrets++;
+
+        // Place bonus pickups in the secret room
+        if (window.game && window.game.pickupManager) {
+            window.game.pickupManager.addPickup(
+                (roomX + 0.5) * this.tileSize,
+                (roomY + 0.5) * this.tileSize,
+                'health_large'
+            );
+        } else {
+            // Defer pickup placement until pickup manager exists
+            this.items.push({
+                x: (roomX + 0.5) * this.tileSize,
+                y: (roomY + 0.5) * this.tileSize,
+                type: 'health',
+                collected: false
+            });
+        }
+    }
+
+    damageSecretWall(mapX, mapY, damage) {
+        for (const wall of this.secretWalls) {
+            if (!wall.active || wall.mapX !== mapX || wall.mapY !== mapY) continue;
+
+            wall.health -= damage;
+            if (wall.health <= 0) {
+                this.destroySecretWall(wall);
+            }
+            return wall;
+        }
+        return null;
+    }
+
+    destroySecretWall(wall) {
+        if (!wall.active) return;
+        wall.active = false;
+
+        // Remove the wall tile — make it passable
+        this.grid[wall.mapY][wall.mapX] = 0;
+
+        this.secretsFound++;
+
+        // Particles
+        if (window.game && window.game.hud) {
+            const worldX = (wall.mapX + 0.5) * this.tileSize;
+            const worldY = (wall.mapY + 0.5) * this.tileSize;
+            window.game.hud.emitExplosionParticles(worldX, worldY, 12);
+            window.game.hud.triggerScreenShake(6);
+        }
+
+        // Sound
+        if (window.soundEngine && window.soundEngine.isInitialized) {
+            window.soundEngine.playWallBreak();
+        }
+
+        // Kill feed
+        if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
+            window.game.hud.addKillFeedMessage(
+                `SECRET FOUND! (${this.secretsFound}/${this.totalSecrets})`,
+                '#FFD700'
+            );
+        }
+
+        // Spawn a valuable pickup in the secret room
+        if (window.game && window.game.pickupManager) {
+            const roomWorldX = (wall.roomX + 0.5) * this.tileSize;
+            const roomWorldY = (wall.roomY + 0.5) * this.tileSize;
+            const rewards = ['health', 'armor', 'ammo_rocket', 'ammo_rifle'];
+            const reward = rewards[Math.floor(Math.random() * rewards.length)];
+            window.game.pickupManager.addPickup(roomWorldX, roomWorldY, reward);
+        }
+
+        console.log(`Secret wall destroyed at (${wall.mapX}, ${wall.mapY})! Secrets: ${this.secretsFound}/${this.totalSecrets}`);
+    }
+
+    getSecretWallAt(mapX, mapY) {
+        return this.secretWalls.find(w => w.active && w.mapX === mapX && w.mapY === mapY);
     }
 
     // Check if a coordinate contains a wall (for entity collision)


### PR DESCRIPTION
## Summary
- Adds 3 hidden secret rooms sealed behind cracked/destructible walls (wall type 10)
- Players can shoot the cracked walls (80 HP each) to break them and reveal secret rooms
- Each room contains bonus pickups (health, armor, ammo)
- HUD displays secrets counter (SECRETS: X/3)
- Kill feed notification in gold when a secret is discovered
- Procedural wall crumble sound effect on destruction

## Test plan
- [x] All 43 existing tests pass (0 failures)
- [x] Secret walls render with distinct golden-brown color/texture
- [x] Shooting cracked walls damages and destroys them
- [x] Destroyed walls become passable, revealing hidden rooms
- [x] Secrets counter updates on HUD
- [x] Wall break sound plays on destruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)