### PR TITLE
Add kill combo/streak system with HUD display

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -1095,6 +1095,47 @@ class SoundEngine {
         }
     }
 
+    playComboTier(comboCount) {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Rising pitch ding based on combo tier
+        const baseFreq = 600 + Math.min(comboCount, 5) * 200;
+
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+
+        osc.type = 'triangle';
+        osc.frequency.setValueAtTime(baseFreq, now);
+        osc.frequency.exponentialRampToValueAtTime(baseFreq * 1.5, now + 0.15);
+
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.6, now + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+
+        osc.start(now);
+        osc.stop(now + 0.3);
+
+        // Second harmonic for richness
+        const osc2 = this.audioContext.createOscillator();
+        const gain2 = this.audioContext.createGain();
+        osc2.connect(gain2);
+        gain2.connect(this.masterGain);
+
+        osc2.type = 'sine';
+        osc2.frequency.setValueAtTime(baseFreq * 2, now + 0.05);
+        osc2.frequency.exponentialRampToValueAtTime(baseFreq * 2.5, now + 0.2);
+
+        gain2.gain.setValueAtTime(0, now + 0.05);
+        gain2.gain.linearRampToValueAtTime(this.sfxVolume * 0.3, now + 0.07);
+        gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.35);
+
+        osc2.start(now + 0.05);
+        osc2.stop(now + 0.35);
+    }
+
     playWallBreak() {
         if (!this.isInitialized) return;
         const now = this.audioContext.currentTime;

--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -371,14 +371,16 @@ class GameEngine {
             ? (stats.shotsHit / stats.shotsFired) * 100
             : 0;
 
-        // Score formula: kills * 100 + accuracy bonus + time bonus - damage penalty
+        // Score formula: kills * 100 + accuracy bonus + time bonus - damage penalty + combo bonus
         const killScore = stats.enemiesKilled * 100;
         const accuracyBonus = Math.round(accuracy * 10);
         const timeBonus = Math.max(0, 300 - Math.floor(elapsed)) * 5; // Faster = more points
         const damagePenalty = Math.round(stats.damageTaken);
         const levelBonus = (this.player.level - 1) * 200;
+        const comboInfo = this.player.getComboInfo ? this.player.getComboInfo() : null;
+        const comboBonus = comboInfo ? (comboInfo.bestStreak * 50 + comboInfo.totalComboKills * 25) : 0;
 
-        return Math.max(0, killScore + accuracyBonus + timeBonus - damagePenalty + levelBonus);
+        return Math.max(0, killScore + accuracyBonus + timeBonus - damagePenalty + levelBonus + comboBonus);
     }
 
     getHighScores() {
@@ -525,6 +527,7 @@ class GameEngine {
             deaths: 0, timeSurvived: 0
         };
         this.player.weaponManager = new WeaponManager();
+        this.player.combo = { count: 0, lastKillTime: 0, window: 3000, bestStreak: 0, totalComboKills: 0 };
 
         // Re-initialize pickups
         this.pickupManager = new PickupManager();
@@ -645,11 +648,17 @@ class GameEngine {
         let y = panelY + 32;
         const lineH = 30;
 
+        const comboInfo = this.player.getComboInfo ? this.player.getComboInfo() : null;
+        const bestStreak = comboInfo ? comboInfo.bestStreak : 0;
+        const comboKills = comboInfo ? comboInfo.totalComboKills : 0;
+
         const statLines = [
             ['Time', timeStr],
             ['Enemies Killed', `${killed} / ${total}`],
             ['Accuracy', `${accuracy}%`],
             ['Damage Taken', `${damageTaken}`],
+            ['Best Combo', `${bestStreak}x`],
+            ['Combo Kills', `${comboKills}`],
             ['Player Level', `${this.player.level}`],
             ['Score', `${this.currentScore}`]
         ];

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -61,6 +61,15 @@ class Player {
         // Weapon system
         this.weaponManager = new WeaponManager();
 
+        // Kill combo system
+        this.combo = {
+            count: 0,
+            lastKillTime: 0,
+            window: 3000, // 3 seconds between kills
+            bestStreak: 0,
+            totalComboKills: 0 // kills that were part of a combo (count >= 2)
+        };
+
         // Melee punch system
         this.punchDamage = 30;
         this.punchRange = 40;
@@ -510,6 +519,7 @@ class Player {
                 const xpTable = { imp: 15, guard: 20, soldier: 30, demon: 40, berserker: 35, spitter: 25, shield_guard: 45, boss: 200 };
                 const xpReward = xpTable[closestEnemy.type] || 20;
                 if (this.addXP) this.addXP(xpReward);
+                this.registerKill();
 
                 // Kill feed message for punch kills
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
@@ -786,6 +796,71 @@ class Player {
         return active;
     }
     
+    // Kill combo system
+    registerKill() {
+        const now = Date.now();
+        const timeSinceLastKill = now - this.combo.lastKillTime;
+
+        if (timeSinceLastKill <= this.combo.window && this.combo.lastKillTime > 0) {
+            this.combo.count++;
+            this.combo.totalComboKills++;
+        } else {
+            this.combo.count = 1;
+        }
+
+        this.combo.lastKillTime = now;
+        if (this.combo.count > this.combo.bestStreak) {
+            this.combo.bestStreak = this.combo.count;
+        }
+
+        // Combo tier thresholds and names
+        const tier = this.getComboTier();
+        if (tier) {
+            // Show combo tier name in kill feed
+            if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
+                window.game.hud.addKillFeedMessage(`${tier.name}! x${this.combo.count}`, '#FFD700');
+            }
+            // Play combo sound
+            if (window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playComboTier) {
+                window.soundEngine.playComboTier(this.combo.count);
+            }
+        }
+    }
+
+    getComboTier() {
+        const tiers = [
+            { min: 5, name: 'UNSTOPPABLE', color: '#FF00FF' },
+            { min: 4, name: 'MEGA KILL', color: '#FF4400' },
+            { min: 3, name: 'MULTI KILL', color: '#FF8800' },
+            { min: 2, name: 'DOUBLE KILL', color: '#FFCC00' }
+        ];
+        for (const tier of tiers) {
+            if (this.combo.count >= tier.min) return tier;
+        }
+        return null;
+    }
+
+    getComboMultiplier() {
+        const multipliers = { 1: 1, 2: 1.5, 3: 2, 4: 2.5 };
+        return multipliers[Math.min(this.combo.count, 5)] || 3;
+    }
+
+    getComboInfo() {
+        const now = Date.now();
+        const elapsed = now - this.combo.lastKillTime;
+        const remaining = Math.max(0, this.combo.window - elapsed);
+        const active = this.combo.count >= 2 && remaining > 0;
+        return {
+            count: this.combo.count,
+            active: active,
+            timerProgress: remaining / this.combo.window,
+            tier: this.getComboTier(),
+            multiplier: this.getComboMultiplier(),
+            bestStreak: this.combo.bestStreak,
+            totalComboKills: this.combo.totalComboKills
+        };
+    }
+
     // Progression methods
     addXP(amount) {
         this.xp += amount;

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -136,6 +136,9 @@ class HUD {
             // Render dash cooldown indicator
             this.renderDashIndicator(player);
 
+            // Render kill combo display
+            this.renderComboDisplay(player);
+
             // Render kill feed
             this.renderKillFeed();
 
@@ -999,6 +1002,52 @@ class HUD {
         this.ctx.strokeStyle = 'rgba(255, 255, 255, 0.2)';
         this.ctx.lineWidth = 1;
         this.ctx.stroke();
+    }
+
+    renderComboDisplay(player) {
+        if (!player.getComboInfo) return;
+        const combo = player.getComboInfo();
+        if (!combo.active) return;
+
+        const cx = this.canvas.width / 2;
+        const baseY = this.canvas.height - 140;
+
+        // Combo count and tier name
+        const tier = combo.tier;
+        if (tier) {
+            // Pulsing glow effect
+            const pulse = 0.7 + 0.3 * Math.sin(Date.now() * 0.01);
+
+            // Tier name
+            this.ctx.save();
+            this.ctx.textAlign = 'center';
+            this.ctx.font = 'bold 20px monospace';
+            this.ctx.globalAlpha = pulse;
+            this.ctx.fillStyle = tier.color;
+            this.ctx.fillText(tier.name, cx, baseY);
+
+            // Multiplier
+            this.ctx.font = 'bold 16px monospace';
+            this.ctx.fillStyle = '#FFFFFF';
+            this.ctx.globalAlpha = 0.9;
+            this.ctx.fillText(`x${combo.count} COMBO`, cx, baseY + 20);
+            this.ctx.restore();
+        }
+
+        // Timer bar
+        const barWidth = 80;
+        const barHeight = 3;
+        const barX = cx - barWidth / 2;
+        const barY = baseY + 28;
+
+        // Background
+        this.ctx.fillStyle = 'rgba(255, 255, 255, 0.2)';
+        this.ctx.fillRect(barX, barY, barWidth, barHeight);
+
+        // Progress
+        const timerColor = combo.timerProgress > 0.3 ? '#FFD700' : '#FF4444';
+        this.ctx.fillStyle = timerColor;
+        this.ctx.fillRect(barX, barY, barWidth * combo.timerProgress, barHeight);
     }
 
     renderSecretsCounter(map) {

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -169,6 +169,7 @@ class Weapon {
                 // Grant XP based on enemy type
                 const xpReward = this.getKillXP(hit.enemy);
                 if (player.addXP) player.addXP(xpReward);
+                if (player.registerKill) player.registerKill();
 
                 // Kill feed message
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
@@ -507,6 +508,7 @@ class Weapon {
                 if (player.stats) player.stats.enemiesKilled++;
                 const xpReward = this.getKillXP(hit.enemy);
                 if (player.addXP) player.addXP(xpReward);
+                if (player.registerKill) player.registerKill();
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (hit.enemy.type || 'enemy').charAt(0).toUpperCase() + (hit.enemy.type || 'enemy').slice(1);
                     window.game.hud.addKillFeedMessage(`ALT! Killed ${typeName} +${xpReward} XP`, '#00CCFF');
@@ -585,6 +587,7 @@ class Weapon {
                 if (player.stats) player.stats.enemiesKilled++;
                 const xpReward = this.getKillXP(hit.enemy);
                 if (player.addXP) player.addXP(xpReward);
+                if (player.registerKill) player.registerKill();
             }
             hit.enemy.hitFlashTime = Date.now();
             if (window.game && window.game.hud) {


### PR DESCRIPTION
## Summary
- Adds a kill combo system that tracks consecutive kills within a 3-second window
- Builds multiplier tiers: DOUBLE KILL, MULTI KILL, MEGA KILL, UNSTOPPABLE
- HUD display with pulsing combo name, count, and draining timer bar
- Procedural rising-pitch combo sound on tier increases
- Combo stats (best streak, combo kills) shown on level completion screen with score bonus

## Test plan
- [x] All 43 existing tests pass
- [x] Combo tracking hooks in fire(), altFire(), processAltHit(), and punch()
- [x] Combo resets cleanly when 3-second window expires
- [x] Score calculation includes combo bonus

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)