### PR TITLE
Add headshot mechanic with precision damage bonus

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -1095,6 +1095,29 @@ class SoundEngine {
         }
     }
 
+    playHeadshot() {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Sharp metallic ping
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(1800, now);
+        osc.frequency.exponentialRampToValueAtTime(3200, now + 0.08);
+        osc.frequency.exponentialRampToValueAtTime(2400, now + 0.15);
+
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.5, now + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.2);
+
+        osc.start(now);
+        osc.stop(now + 0.2);
+    }
+
     playComboTier(comboCount) {
         if (!this.isInitialized) return;
         const now = this.audioContext.currentTime;

--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -522,7 +522,7 @@ class GameEngine {
         this.player.armor = 0;
         this.player.isDead = false;
         this.player.stats = {
-            enemiesKilled: 0, shotsFired: 0, shotsHit: 0,
+            enemiesKilled: 0, shotsFired: 0, shotsHit: 0, headshots: 0,
             damageTaken: 0, damageDealt: 0, itemsCollected: 0,
             deaths: 0, timeSurvived: 0
         };
@@ -635,7 +635,7 @@ class GameEngine {
         const panelX = w * 0.2;
         const panelY = h * 0.23;
         const panelW = w * 0.6;
-        const panelH = h * 0.46;
+        const panelH = h * 0.50;
         ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
         ctx.fillRect(panelX, panelY, panelW, panelH);
         ctx.strokeStyle = '#FFD700';
@@ -652,10 +652,14 @@ class GameEngine {
         const bestStreak = comboInfo ? comboInfo.bestStreak : 0;
         const comboKills = comboInfo ? comboInfo.totalComboKills : 0;
 
+        const headshots = stats.headshots || 0;
+        const headshotPct = stats.shotsHit > 0 ? Math.round((headshots / stats.shotsHit) * 100) : 0;
+
         const statLines = [
             ['Time', timeStr],
             ['Enemies Killed', `${killed} / ${total}`],
             ['Accuracy', `${accuracy}%`],
+            ['Headshots', `${headshots} (${headshotPct}%)`],
             ['Damage Taken', `${damageTaken}`],
             ['Best Combo', `${bestStreak}x`],
             ['Combo Kills', `${comboKills}`],

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -44,6 +44,7 @@ class Player {
             enemiesKilled: 0,
             shotsFired: 0,
             shotsHit: 0,
+            headshots: 0,
             damageTaken: 0,
             damageDealt: 0,
             itemsCollected: 0,

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -1125,9 +1125,9 @@ class HUD {
     }
 
     // Add a floating damage number
-    addDamageNumber(worldX, worldY, damage, isCritical) {
+    addDamageNumber(worldX, worldY, damage, isCritical, isHeadshot) {
         this.damageNumbers.push({
-            worldX, worldY, damage, isCritical,
+            worldX, worldY, damage, isCritical, isHeadshot: isHeadshot || false,
             spawnTime: Date.now(),
             duration: 1000,
             offsetY: 0
@@ -1174,14 +1174,21 @@ class HUD {
             const screenY = baseY - 20 - (progress * 40); // Float upward
 
             const alpha = 1 - progress;
-            const fontSize = dn.isCritical ? 20 : 14;
+            const fontSize = dn.isHeadshot ? 22 : (dn.isCritical ? 20 : 14);
 
             this.ctx.font = `bold ${fontSize}px monospace`;
             this.ctx.textAlign = 'center';
-            this.ctx.fillStyle = dn.isCritical
-                ? `rgba(255, 255, 0, ${alpha})`
-                : `rgba(255, 100, 100, ${alpha})`;
-            this.ctx.fillText(dn.damage.toString(), screenX, screenY);
+            if (dn.isHeadshot) {
+                this.ctx.fillStyle = `rgba(255, 215, 0, ${alpha})`;
+                this.ctx.fillText(dn.damage.toString(), screenX, screenY);
+                this.ctx.font = 'bold 10px monospace';
+                this.ctx.fillText('HEADSHOT', screenX, screenY - 14);
+            } else {
+                this.ctx.fillStyle = dn.isCritical
+                    ? `rgba(255, 255, 0, ${alpha})`
+                    : `rgba(255, 100, 100, ${alpha})`;
+                this.ctx.fillText(dn.damage.toString(), screenX, screenY);
+            }
         }
     }
 

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -142,7 +142,14 @@ class Weapon {
                 actualDamage *= 0.3; // Partial damage on inaccurate shots
             }
 
-            // Critical hit (10% chance for 2x damage)
+            // Headshot: 2x damage for upper sprite hit
+            const isHeadshot = hit.isHeadshot;
+            if (isHeadshot) {
+                actualDamage *= 2;
+                if (player.stats) player.stats.headshots++;
+            }
+
+            // Critical hit (10% chance for 2x damage, stacks with headshot)
             let isCritical = Math.random() < 0.1;
             if (isCritical) {
                 actualDamage *= 2;
@@ -174,8 +181,8 @@ class Weapon {
                 // Kill feed message
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (hit.enemy.type || 'enemy').charAt(0).toUpperCase() + (hit.enemy.type || 'enemy').slice(1);
-                    const prefix = isCritical ? 'CRITICAL! Killed' : 'Killed';
-                    const color = isCritical ? '#FFD700' : '#FF4444';
+                    const prefix = isHeadshot ? 'HEADSHOT! Killed' : (isCritical ? 'CRITICAL! Killed' : 'Killed');
+                    const color = isHeadshot ? '#FFD700' : (isCritical ? '#FFD700' : '#FF4444');
                     window.game.hud.addKillFeedMessage(`${prefix} ${typeName} +${xpReward} XP`, color);
                 }
             }
@@ -186,12 +193,17 @@ class Weapon {
                 window.game.hud.emitBloodParticles(hit.enemy.x, hit.enemy.y, wasAlive && hit.enemy.dying ? 12 : 5);
             }
 
-            // Show floating damage number
+            // Show floating damage number (gold for headshots)
             if (window.game && window.game.hud) {
-                window.game.hud.addDamageNumber(hit.enemy.x, hit.enemy.y, actualDamage, isCritical);
+                window.game.hud.addDamageNumber(hit.enemy.x, hit.enemy.y, actualDamage, isCritical || isHeadshot, isHeadshot);
             }
 
-            console.log(`${isCritical ? 'CRITICAL! ' : ''}Hit enemy for ${actualDamage} damage! Enemy health: ${hit.enemy.health}`);
+            // Headshot sound
+            if (isHeadshot && window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playHeadshot) {
+                window.soundEngine.playHeadshot();
+            }
+
+            console.log(`${isHeadshot ? 'HEADSHOT! ' : ''}${isCritical ? 'CRITICAL! ' : ''}Hit enemy for ${actualDamage} damage! Enemy health: ${hit.enemy.health}`);
         }
 
         // Barrel hit — damage barrel, explode if destroyed
@@ -375,12 +387,22 @@ class Weapon {
             if (sw) hitSecretWall = sw;
         }
 
+        // Headshot detection: based on accuracy and distance (simulates upper sprite hit)
+        // Closer range + higher accuracy = higher headshot probability
+        let isHeadshot = false;
+        if (closestEnemy) {
+            const distRatio = closestDistance / this.range;
+            const headshotChance = this.accuracy * Math.max(0.1, 1 - distRatio * 0.8) * 0.3;
+            isHeadshot = Math.random() < headshotChance;
+        }
+
         return {
             enemy: closestEnemy,
             barrel: closestBarrel,
             crate: closestCrate,
             secretWall: hitSecretWall,
             distance: closestDistance,
+            isHeadshot: isHeadshot,
             hitPoint: { x: currentX, y: currentY },
             hitWall: !closestEnemy && map.isWallAtPosition(currentX, currentY)
         };
@@ -494,6 +516,11 @@ class Weapon {
         if (hit.enemy) {
             if (player.stats) player.stats.shotsHit++;
             let actualDamage = this.getModdedDamage() * (altStats.damageMultiplier || 1);
+            const isHeadshot = hit.isHeadshot;
+            if (isHeadshot) {
+                actualDamage *= 2;
+                if (player.stats) player.stats.headshots++;
+            }
             let isCritical = Math.random() < 0.1;
             if (isCritical) actualDamage *= 2;
             if (player.hasDamageBoost && player.hasDamageBoost()) actualDamage *= 1.5;
@@ -511,14 +538,18 @@ class Weapon {
                 if (player.registerKill) player.registerKill();
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (hit.enemy.type || 'enemy').charAt(0).toUpperCase() + (hit.enemy.type || 'enemy').slice(1);
-                    window.game.hud.addKillFeedMessage(`ALT! Killed ${typeName} +${xpReward} XP`, '#00CCFF');
+                    const prefix = isHeadshot ? 'HEADSHOT!' : 'ALT!';
+                    window.game.hud.addKillFeedMessage(`${prefix} Killed ${typeName} +${xpReward} XP`, isHeadshot ? '#FFD700' : '#00CCFF');
                 }
             }
 
             hit.enemy.hitFlashTime = Date.now();
             if (window.game && window.game.hud) {
                 window.game.hud.emitBloodParticles(hit.enemy.x, hit.enemy.y, wasAlive && hit.enemy.dying ? 12 : 5);
-                window.game.hud.addDamageNumber(hit.enemy.x, hit.enemy.y, actualDamage, isCritical);
+                window.game.hud.addDamageNumber(hit.enemy.x, hit.enemy.y, actualDamage, isCritical || isHeadshot, isHeadshot);
+            }
+            if (isHeadshot && window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playHeadshot) {
+                window.soundEngine.playHeadshot();
             }
         }
 
@@ -574,6 +605,11 @@ class Weapon {
         if (hit.enemy) {
             if (player.stats) player.stats.shotsHit++;
             let actualDamage = this.getModdedDamage() * damageMultiplier;
+            const isHeadshot = hit.isHeadshot;
+            if (isHeadshot) {
+                actualDamage *= 2;
+                if (player.stats) player.stats.headshots++;
+            }
             let isCritical = Math.random() < 0.1;
             if (isCritical) actualDamage *= 2;
             if (player.hasDamageBoost && player.hasDamageBoost()) actualDamage *= 1.5;
@@ -590,9 +626,12 @@ class Weapon {
                 if (player.registerKill) player.registerKill();
             }
             hit.enemy.hitFlashTime = Date.now();
+            if (isHeadshot && window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playHeadshot) {
+                window.soundEngine.playHeadshot();
+            }
             if (window.game && window.game.hud) {
                 window.game.hud.emitBloodParticles(hit.enemy.x, hit.enemy.y, 5);
-                window.game.hud.addDamageNumber(hit.enemy.x, hit.enemy.y, actualDamage, isCritical);
+                window.game.hud.addDamageNumber(hit.enemy.x, hit.enemy.y, actualDamage, isCritical || isHeadshot, isHeadshot);
             }
         }
         if (hit.barrel && hit.barrel.active) {


### PR DESCRIPTION
## Summary
- Adds headshot detection based on weapon accuracy and distance (higher accuracy + closer range = more headshots)
- 2x damage multiplier for headshots, stacks with critical hits
- Gold damage numbers with "HEADSHOT" label, metallic ping sound cue
- Headshot stats (count + percentage) tracked and shown on level completion screen

## Test plan
- [x] All 43 existing tests pass
- [x] Headshot detection in fire(), altFire(), and processAltHit()
- [x] Gold damage numbers display correctly for headshots
- [x] Stats properly reset on level restart

Fixes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)