### PR TITLE
Add enemy wave spawner system

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -1494,6 +1494,32 @@ class SoundEngine {
         return buffer;
     }
     
+    playWaveAnnounce(waveNumber) {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Ominous descending alarm — two low tones
+        const baseFreq = 200 + Math.min(waveNumber, 10) * 20;
+        for (let i = 0; i < 2; i++) {
+            const osc = this.audioContext.createOscillator();
+            const gain = this.audioContext.createGain();
+            osc.connect(gain);
+            gain.connect(this.masterGain);
+
+            osc.type = 'sawtooth';
+            const t = now + i * 0.25;
+            osc.frequency.setValueAtTime(baseFreq, t);
+            osc.frequency.exponentialRampToValueAtTime(baseFreq * 0.5, t + 0.2);
+
+            gain.gain.setValueAtTime(0, t);
+            gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.4, t + 0.03);
+            gain.gain.exponentialRampToValueAtTime(0.001, t + 0.25);
+
+            osc.start(t);
+            osc.stop(t + 0.25);
+        }
+    }
+
     // Set master volume
     setMasterVolume(volume) {
         this.masterVolume = Math.max(0, Math.min(1, volume));

--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -58,6 +58,27 @@ class GameEngine {
         this.pauseMenuSelection = -1;
         this._pauseMenuItems = [];
 
+        // Wave spawner system
+        this.waveSystem = {
+            active: false,
+            currentWave: 0,
+            state: 'idle', // idle, announcing, spawning, fighting
+            announceTime: 0,
+            announceDuration: 2000, // 2s announcement
+            delayBetweenWaves: 3000, // 3s between waves
+            lastWaveClearTime: 0,
+            spawnPoints: [
+                { x: 14, y: 8 },
+                { x: 4, y: 16 },
+                { x: 12, y: 16 },
+                { x: 8, y: 12 },
+                { x: 20, y: 8 },
+                { x: 8, y: 4 },
+                { x: 16, y: 12 },
+                { x: 4, y: 12 }
+            ]
+        };
+
         // Initialize systems
         this.initialize();
     }
@@ -203,9 +224,15 @@ class GameEngine {
         this.hud.resetFog();
         this.levelStartTime = performance.now();
         this.totalEnemyCount = this.map.enemies.length;
+
+        // Reset wave system
+        this.waveSystem.active = false;
+        this.waveSystem.currentWave = 0;
+        this.waveSystem.state = 'idle';
+
         console.log('Level restarted');
     }
-    
+
     gameLoop(currentTime = performance.now()) {
         if (!this.running) return;
         
@@ -347,19 +374,114 @@ class GameEngine {
 
         const activeEnemies = this.map.enemies.filter(e => e.active && !e.dying);
         if (activeEnemies.length === 0 && this.totalEnemyCount > 0) {
-            this.levelComplete = true;
-            this.levelCompleteTime = performance.now();
-            console.log('Level complete! All enemies eliminated.');
+            // Wave system: spawn next wave instead of ending level
+            this.updateWaveSystem();
+        }
+    }
 
-            // Calculate and save score
-            this.currentScore = this.calculateScore();
-            this.saveHighScore(this.currentScore);
+    updateWaveSystem() {
+        const ws = this.waveSystem;
+        const now = performance.now();
 
-            // Play victory sound
-            if (window.soundEngine && window.soundEngine.isInitialized) {
-                window.soundEngine.playLevelComplete();
+        if (ws.state === 'idle') {
+            // First time all enemies cleared — start wave countdown
+            ws.active = true;
+            ws.lastWaveClearTime = now;
+            ws.state = 'waiting';
+        }
+
+        if (ws.state === 'waiting') {
+            if (now - ws.lastWaveClearTime >= ws.delayBetweenWaves) {
+                ws.currentWave++;
+                ws.state = 'announcing';
+                ws.announceTime = now;
+
+                // Show wave announcement in HUD
+                if (this.hud && this.hud.addKillFeedMessage) {
+                    this.hud.addKillFeedMessage(`WAVE ${ws.currentWave} INCOMING!`, '#FF4444');
+                }
+
+                // Play wave announcement sound
+                if (window.soundEngine && window.soundEngine.isInitialized) {
+                    window.soundEngine.playWaveAnnounce(ws.currentWave);
+                }
+
+                console.log(`Wave ${ws.currentWave} incoming!`);
             }
         }
+
+        if (ws.state === 'announcing') {
+            if (now - ws.announceTime >= ws.announceDuration) {
+                this.spawnWave(ws.currentWave);
+                ws.state = 'fighting';
+            }
+        }
+
+        if (ws.state === 'fighting') {
+            const alive = this.map.enemies.filter(e => e.active && !e.dying);
+            if (alive.length === 0) {
+                ws.lastWaveClearTime = now;
+                ws.state = 'waiting';
+            }
+        }
+    }
+
+    spawnWave(waveNumber) {
+        const ws = this.waveSystem;
+        const tileSize = this.map.tileSize;
+        const difficulty = window.CONFIG ? window.CONFIG.difficulty : 'normal';
+        const diffSettings = window.DIFFICULTY ? window.DIFFICULTY[difficulty] : null;
+
+        // Wave composition scales with wave number
+        const baseCount = 3 + Math.floor(waveNumber * 1.5);
+        const count = difficulty === 'nightmare' ? baseCount + 2 :
+                      difficulty === 'easy' ? Math.max(2, baseCount - 2) : baseCount;
+
+        // Enemy types available per wave (harder types appear in later waves)
+        const earlyTypes = ['guard', 'imp'];
+        const midTypes = ['guard', 'imp', 'soldier', 'berserker'];
+        const lateTypes = ['guard', 'imp', 'soldier', 'berserker', 'spitter', 'shield_guard'];
+        const bossTypes = ['guard', 'imp', 'soldier', 'berserker', 'spitter', 'shield_guard', 'demon', 'boss'];
+
+        let typePool;
+        if (waveNumber <= 2) typePool = earlyTypes;
+        else if (waveNumber <= 4) typePool = midTypes;
+        else if (waveNumber <= 7) typePool = lateTypes;
+        else typePool = bossTypes;
+
+        // Filter spawn points far enough from player
+        const playerX = this.player.x;
+        const playerY = this.player.y;
+        const minSpawnDist = 5 * tileSize;
+        const validSpawns = ws.spawnPoints.filter(sp => {
+            const dx = sp.x * tileSize - playerX;
+            const dy = sp.y * tileSize - playerY;
+            return Math.sqrt(dx * dx + dy * dy) >= minSpawnDist;
+        });
+        const spawns = validSpawns.length > 0 ? validSpawns : ws.spawnPoints;
+
+        for (let i = 0; i < count; i++) {
+            const sp = spawns[i % spawns.length];
+            const type = typePool[Math.floor(Math.random() * typePool.length)];
+            const enemy = new Enemy(sp.x * tileSize, sp.y * tileSize, type);
+
+            // Apply difficulty scaling
+            if (diffSettings) {
+                enemy.health = Math.round(enemy.health * diffSettings.enemyHealthMultiplier);
+                enemy.maxHealth = Math.round(enemy.maxHealth * diffSettings.enemyHealthMultiplier);
+                enemy.speed = Math.round(enemy.speed * diffSettings.enemySpeedMultiplier);
+                if (enemy.enhancedAI && enemy.enhancedAI.behavior) {
+                    enemy.enhancedAI.behavior.damage = Math.round(
+                        enemy.enhancedAI.behavior.damage * diffSettings.enemyDamageMultiplier
+                    );
+                }
+            }
+
+            this.map.enemies.push(enemy);
+        }
+
+        this.totalEnemyCount += count;
+        console.log(`Wave ${waveNumber}: spawned ${count} enemies`);
     }
 
     // ========== HIGH SCORE SYSTEM ==========
@@ -553,6 +675,11 @@ class GameEngine {
 
         this.totalEnemyCount = this.map.enemies.length;
         this.levelStartTime = performance.now();
+
+        // Reset wave system
+        this.waveSystem.active = false;
+        this.waveSystem.currentWave = 0;
+        this.waveSystem.state = 'idle';
 
         // Reset dynamic difficulty
         this.initDifficultyScaler();

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -139,6 +139,11 @@ class HUD {
             // Render kill combo display
             this.renderComboDisplay(player);
 
+            // Render wave indicator
+            if (gameEngine && gameEngine.waveSystem && gameEngine.waveSystem.active) {
+                this.renderWaveIndicator(gameEngine.waveSystem);
+            }
+
             // Render kill feed
             this.renderKillFeed();
 
@@ -1048,6 +1053,50 @@ class HUD {
         const timerColor = combo.timerProgress > 0.3 ? '#FFD700' : '#FF4444';
         this.ctx.fillStyle = timerColor;
         this.ctx.fillRect(barX, barY, barWidth * combo.timerProgress, barHeight);
+    }
+
+    renderWaveIndicator(waveSystem) {
+        const w = this.canvas.width;
+        const ctx = this.ctx;
+
+        // Wave number display (top-right area, below FPS)
+        const x = w - 20;
+        const y = 45;
+
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+        ctx.fillRect(x - 110, y - 14, 112, 20);
+
+        ctx.font = 'bold 14px monospace';
+        ctx.textAlign = 'right';
+        ctx.fillStyle = '#FF4444';
+        ctx.fillText(`WAVE ${waveSystem.currentWave}`, x, y);
+
+        // "WAVE INCOMING" center-screen announcement
+        if (waveSystem.state === 'announcing') {
+            const elapsed = performance.now() - waveSystem.announceTime;
+            const alpha = Math.min(1, 1 - (elapsed / waveSystem.announceDuration) * 0.5);
+            const pulse = 1 + 0.05 * Math.sin(elapsed * 0.01);
+            const fontSize = Math.round(32 * pulse);
+
+            ctx.save();
+            ctx.globalAlpha = alpha;
+            ctx.font = `bold ${fontSize}px monospace`;
+            ctx.textAlign = 'center';
+
+            // Shadow
+            ctx.fillStyle = '#000000';
+            ctx.fillText(`WAVE ${waveSystem.currentWave}`, w / 2 + 2, 182);
+
+            // Text
+            ctx.fillStyle = '#FF4444';
+            ctx.fillText(`WAVE ${waveSystem.currentWave}`, w / 2, 180);
+
+            ctx.font = 'bold 18px monospace';
+            ctx.fillStyle = '#FFAA00';
+            ctx.fillText('INCOMING!', w / 2, 210);
+
+            ctx.restore();
+        }
     }
 
     renderSecretsCounter(map) {


### PR DESCRIPTION
## Summary
- After all initial enemies are cleared, progressive enemy waves spawn instead of ending the level
- Wave number displayed on HUD (top-right) with center-screen "WAVE X INCOMING!" announcement
- Enemy count and types scale per wave: early waves use guards/imps, later waves add all enemy types including bosses
- Spawn points chosen far from player, difficulty settings applied to all spawned enemies
- Ominous procedural alarm sound plays on wave announcement

## Test plan
- [x] All 43 existing tests pass
- [ ] Verify waves spawn after clearing initial enemies
- [ ] Verify wave number displays on HUD
- [ ] Verify announcement shows between waves
- [ ] Verify enemy types scale with wave number

Fixes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)