### PR TITLE
Add enhanced low health warning effects

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -1494,6 +1494,32 @@ class SoundEngine {
         return buffer;
     }
     
+    playHeartbeat(intensity) {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+        const vol = this.sfxVolume * (0.2 + intensity * 0.3);
+
+        // Double-thump heartbeat (lub-dub)
+        for (let i = 0; i < 2; i++) {
+            const osc = this.audioContext.createOscillator();
+            const gain = this.audioContext.createGain();
+            osc.connect(gain);
+            gain.connect(this.masterGain);
+
+            const t = now + i * 0.12;
+            osc.type = 'sine';
+            osc.frequency.setValueAtTime(i === 0 ? 60 : 45, t);
+            osc.frequency.exponentialRampToValueAtTime(30, t + 0.1);
+
+            gain.gain.setValueAtTime(0, t);
+            gain.gain.linearRampToValueAtTime(vol, t + 0.02);
+            gain.gain.exponentialRampToValueAtTime(0.001, t + 0.12);
+
+            osc.start(t);
+            osc.stop(t + 0.15);
+        }
+    }
+
     playWaveAnnounce(waveNumber) {
         if (!this.isInitialized) return;
         const now = this.audioContext.currentTime;

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -63,6 +63,9 @@ class HUD {
         this.inHazardZone = false;
         this.hazardType = null; // 'acid' or 'lava'
 
+        // Low health heartbeat tracking
+        this.lastHeartbeatTime = 0;
+
         // Load weapon sprite images (from FPS Starter Kit, CC0)
         this.weaponImages = {};
         this.loadWeaponImages();
@@ -678,9 +681,16 @@ class HUD {
         }
 
         // Low-health pulse: vignette red border when health < 25%
+        // Intensity scales inversely with health (lower health = stronger effect)
         if (player.health > 0 && player.health < player.maxHealth * 0.25) {
-            const pulseAlpha = (Math.sin(now * 0.005) * 0.5 + 0.5) * 0.35;
-            const edgeSize = 80;
+            const healthRatio = player.health / (player.maxHealth * 0.25); // 1.0 at 25%, 0.0 at 0%
+            const intensity = 1 - healthRatio; // 0.0 at 25%, 1.0 near 0%
+            const pulseSpeed = 0.004 + intensity * 0.006; // Faster pulse at lower health
+            const pulseAlpha = (Math.sin(now * pulseSpeed) * 0.5 + 0.5) * (0.2 + intensity * 0.4);
+            const edgeSize = 80 + intensity * 40; // Larger vignette at lower health
+
+            // Trigger heartbeat sound
+            this.playLowHealthHeartbeat(player, now);
 
             // Top edge
             const gradTop = this.ctx.createLinearGradient(0, 0, 0, edgeSize);
@@ -712,6 +722,19 @@ class HUD {
         }
     }
     
+    playLowHealthHeartbeat(player, now) {
+        const healthRatio = player.health / (player.maxHealth * 0.25);
+        // Heartbeat interval: 800ms at 25% health, 400ms near death
+        const interval = 400 + healthRatio * 400;
+
+        if (now - this.lastHeartbeatTime >= interval) {
+            this.lastHeartbeatTime = now;
+            if (window.soundEngine && window.soundEngine.isInitialized) {
+                window.soundEngine.playHeartbeat(1 - healthRatio);
+            }
+        }
+    }
+
     renderHazardWarning() {
         if (!this.inHazardZone) return;
 


### PR DESCRIPTION
## Summary
- Low health vignette intensity and pulse speed now scale inversely with health
- Vignette edge size grows as health drops (80px at 25% to 120px near death)
- Procedural heartbeat sound (lub-dub double thump) plays when health < 25%
- Heartbeat rate increases as health decreases (800ms interval at 25%, 400ms near death)

## Test plan
- [x] All 43 existing tests pass
- [ ] Verify vignette intensity increases as health drops
- [ ] Verify heartbeat sound plays at low health
- [ ] Verify heartbeat rate increases at lower health
- [ ] Verify effects stop when health restored above 25%

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)