### PR TITLE
Add explosion knockback for barrels and rockets

### DIFF
--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -37,6 +37,10 @@ class Enemy {
         this.barkCooldown = 2000; // Minimum 2s between barks
         this.hasPlayedAlert = false;
 
+        // Knockback velocity (from explosions)
+        this.knockbackVX = 0;
+        this.knockbackVY = 0;
+
         // Death animation
         this.dying = false;
         this.deathTime = 0;
@@ -69,6 +73,22 @@ class Enemy {
             this.originalUpdate(deltaTime, player, map);
             // Move toward the target set by original AI
             this.moveTowardsTarget(deltaTime, map);
+        }
+
+        // Apply knockback
+        if (Math.abs(this.knockbackVX) > 0.5 || Math.abs(this.knockbackVY) > 0.5) {
+            const kbNewX = this.x + this.knockbackVX * deltaTime;
+            const kbNewY = this.y + this.knockbackVY * deltaTime;
+            if (map && !map.isWallAtPosition(kbNewX, this.y)) {
+                this.x = kbNewX;
+            }
+            if (map && !map.isWallAtPosition(this.x, kbNewY)) {
+                this.y = kbNewY;
+            }
+            this.knockbackVX *= 0.85;
+            this.knockbackVY *= 0.85;
+            if (Math.abs(this.knockbackVX) < 0.5) this.knockbackVX = 0;
+            if (Math.abs(this.knockbackVY) < 0.5) this.knockbackVY = 0;
         }
 
         this.updateFacing(player);
@@ -272,6 +292,16 @@ class Enemy {
         return true;
     }
     
+    applyKnockback(sourceX, sourceY, force) {
+        const dx = this.x - sourceX;
+        const dy = this.y - sourceY;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist > 0) {
+            this.knockbackVX += (dx / dist) * force;
+            this.knockbackVY += (dy / dist) * force;
+        }
+    }
+
     takeDamage(damage) {
         let actualDamage = damage;
 

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -109,6 +109,10 @@ class Player {
         this.onGround = true;
         this.canJump = true;
         
+        // Knockback velocity (from explosions)
+        this.knockbackVX = 0;
+        this.knockbackVY = 0;
+
         // Animation and effects
         this.bobOffset = 0;
         this.bobSpeed = 8;
@@ -279,11 +283,38 @@ class Player {
         this.updatePhysics(deltaTime);
     }
     
+    applyKnockback(sourceX, sourceY, force) {
+        const dx = this.x - sourceX;
+        const dy = this.y - sourceY;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist > 0) {
+            this.knockbackVX += (dx / dist) * force;
+            this.knockbackVY += (dy / dist) * force;
+        }
+    }
+
     updatePosition(deltaTime, map) {
         // Store original position for collision resolution
         const originalX = this.x;
         const originalY = this.y;
-        
+
+        // Apply knockback velocity
+        if (Math.abs(this.knockbackVX) > 0.5 || Math.abs(this.knockbackVY) > 0.5) {
+            const kbNewX = this.x + this.knockbackVX * deltaTime;
+            if (!this.checkCollision(kbNewX, this.y, map)) {
+                this.x = kbNewX;
+            }
+            const kbNewY = this.y + this.knockbackVY * deltaTime;
+            if (!this.checkCollision(this.x, kbNewY, map)) {
+                this.y = kbNewY;
+            }
+            // Decay knockback
+            this.knockbackVX *= 0.85;
+            this.knockbackVY *= 0.85;
+            if (Math.abs(this.knockbackVX) < 0.5) this.knockbackVX = 0;
+            if (Math.abs(this.knockbackVY) < 0.5) this.knockbackVY = 0;
+        }
+
         // Try to move on X axis
         const newX = this.x + this.velocityX;
         if (!this.checkCollision(newX, this.y, map)) {

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -246,7 +246,7 @@ class Weapon {
             const splashRadius = stats.splashRadius;
             const splashDamage = this.damage * 0.5;
 
-            // Damage all enemies in splash radius
+            // Damage all enemies in splash radius + knockback
             map.enemies.forEach(enemy => {
                 if (!enemy.active || enemy.dying) return;
                 if (enemy === hit.enemy) return; // Already took direct hit
@@ -260,20 +260,32 @@ class Weapon {
                     if (window.game && window.game.hud) {
                         window.game.hud.addDamageNumber(enemy.x, enemy.y, dmg, false);
                     }
+                    if (enemy.applyKnockback) {
+                        enemy.applyKnockback(hit.hitPoint.x, hit.hitPoint.y, 500 * falloff);
+                    }
                 }
             });
 
-            // Self damage if player is too close
+            // Knockback on direct-hit enemy too
+            if (hit.enemy && hit.enemy.applyKnockback) {
+                hit.enemy.applyKnockback(hit.hitPoint.x, hit.hitPoint.y, 500);
+            }
+
+            // Self damage + knockback if player is too close
             const playerDist = Math.sqrt(
                 (player.x - hit.hitPoint.x) ** 2 + (player.y - hit.hitPoint.y) ** 2
             );
             if (playerDist < splashRadius) {
-                const selfDmg = Math.round(splashDamage * (1 - playerDist / splashRadius) * (stats.selfDamageMultiplier || 1));
+                const falloff = 1 - (playerDist / splashRadius);
+                const selfDmg = Math.round(splashDamage * falloff * (stats.selfDamageMultiplier || 1));
                 if (selfDmg > 0) {
                     player.takeDamage(selfDmg);
                     if (window.game && window.game.hud) {
                         window.game.hud.onPlayerDamageFrom(hit.hitPoint.x, hit.hitPoint.y);
                     }
+                }
+                if (player.applyKnockback) {
+                    player.applyKnockback(hit.hitPoint.x, hit.hitPoint.y, 400 * falloff);
                 }
             }
         }
@@ -502,14 +514,21 @@ class Weapon {
                     if (window.game && window.game.hud) {
                         window.game.hud.addDamageNumber(enemy.x, enemy.y, dmg, false);
                     }
+                    if (enemy.applyKnockback) {
+                        enemy.applyKnockback(burstX, burstY, 500 * falloff);
+                    }
                 }
             });
 
-            // Self damage
+            // Self damage + knockback
             const playerDist = Math.sqrt((player.x - burstX) ** 2 + (player.y - burstY) ** 2);
             if (playerDist < splashRadius) {
-                const selfDmg = Math.round(splashDamage * (1 - playerDist / splashRadius) * 0.5);
+                const falloff = 1 - (playerDist / splashRadius);
+                const selfDmg = Math.round(splashDamage * falloff * 0.5);
                 if (selfDmg > 0) player.takeDamage(selfDmg);
+                if (player.applyKnockback) {
+                    player.applyKnockback(burstX, burstY, 400 * falloff);
+                }
             }
 
             if (this.ammo === 0) this.startReload();

--- a/js/world/map.js
+++ b/js/world/map.js
@@ -362,7 +362,7 @@ class GameMap {
             window.soundEngine.playExplosion();
         }
 
-        // Damage player
+        // Damage player + knockback
         if (window.game && window.game.player) {
             const player = window.game.player;
             const dx = player.x - barrel.x;
@@ -373,10 +373,14 @@ class GameMap {
                 const dmg = Math.round(barrel.explodeDamage * falloff);
                 player.takeDamage(dmg);
                 if (window.game.hud) window.game.hud.onPlayerDamageFrom(barrel.x, barrel.y);
+                // Knockback: 400 force at center, scaled by falloff
+                if (player.applyKnockback) {
+                    player.applyKnockback(barrel.x, barrel.y, 400 * falloff);
+                }
             }
         }
 
-        // Damage enemies
+        // Damage enemies + knockback
         this.enemies.forEach(enemy => {
             if (!enemy.active) return;
             const dx = enemy.x - barrel.x;
@@ -388,6 +392,10 @@ class GameMap {
                 enemy.takeDamage(dmg);
                 if (window.game && window.game.hud) {
                     window.game.hud.addDamageNumber(enemy.x, enemy.y, dmg, false);
+                }
+                // Knockback: 500 force at center, scaled by falloff
+                if (enemy.applyKnockback) {
+                    enemy.applyKnockback(barrel.x, barrel.y, 500 * falloff);
                 }
             }
         });


### PR DESCRIPTION
## Summary
- Barrel and rocket explosions now apply knockback force to nearby players and enemies
- Force scales inversely with distance from blast center (400 force for player, 500 for enemies)
- Knockback velocity decays smoothly (0.85 per frame) and respects wall collisions
- Applies to barrel explosions, rocket primary fire splash, and rocket alt-fire air burst
- Barrel chain reactions already existed and continue to work

## Test plan
- [x] All 43 existing tests pass
- [ ] Walk near a barrel and shoot it — player should get pushed away
- [ ] Shoot a rocket near enemies — they should get knocked back
- [ ] Chain reaction barrels push entities from each explosion

Fixes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)