### PR TITLE
Add hit markers for visual shot feedback

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -362,6 +362,45 @@ class SoundEngine {
     }
 
     // Enemy hit/damage sound
+    playHitMarker(type = 'normal') {
+        if (!this.isInitialized) return;
+
+        const now = this.audioContext.currentTime;
+        const oscillator = this.audioContext.createOscillator();
+        const gainNode = this.audioContext.createGain();
+
+        oscillator.connect(gainNode);
+        gainNode.connect(this.masterGain);
+
+        // Short high-pitched ping — distinct from enemy hit thud
+        oscillator.type = 'sine';
+        if (type === 'headshot') {
+            oscillator.frequency.setValueAtTime(1800, now);
+            oscillator.frequency.exponentialRampToValueAtTime(2400, now + 0.06);
+            gainNode.gain.setValueAtTime(0, now);
+            gainNode.gain.linearRampToValueAtTime(this.sfxVolume * 0.3, now + 0.01);
+            gainNode.gain.exponentialRampToValueAtTime(0.001, now + 0.12);
+            oscillator.start(now);
+            oscillator.stop(now + 0.12);
+        } else if (type === 'critical') {
+            oscillator.frequency.setValueAtTime(1400, now);
+            oscillator.frequency.exponentialRampToValueAtTime(1800, now + 0.06);
+            gainNode.gain.setValueAtTime(0, now);
+            gainNode.gain.linearRampToValueAtTime(this.sfxVolume * 0.25, now + 0.01);
+            gainNode.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
+            oscillator.start(now);
+            oscillator.stop(now + 0.1);
+        } else {
+            oscillator.frequency.setValueAtTime(1200, now);
+            oscillator.frequency.exponentialRampToValueAtTime(1500, now + 0.04);
+            gainNode.gain.setValueAtTime(0, now);
+            gainNode.gain.linearRampToValueAtTime(this.sfxVolume * 0.2, now + 0.01);
+            gainNode.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
+            oscillator.start(now);
+            oscillator.stop(now + 0.08);
+        }
+    }
+
     playEnemyHit() {
         if (!this.isInitialized) return;
         

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -68,6 +68,11 @@ class HUD {
         this.inHazardZone = false;
         this.hazardType = null; // 'acid' or 'lava'
 
+        // Hit markers
+        this.hitMarkerTime = 0;
+        this.hitMarkerDuration = 150; // ms
+        this.hitMarkerType = 'normal'; // 'normal', 'headshot', 'critical'
+
         // Low health heartbeat tracking
         this.lastHeartbeatTime = 0;
 
@@ -335,21 +340,21 @@ class HUD {
     
     renderCrosshair() {
         if (!this.showCrosshair) return;
-        
+
         const centerX = this.canvas.width / 2;
         const centerY = this.canvas.height / 2;
         const size = 10;
         const gap = 3;
-        
+
         this.ctx.strokeStyle = '#FFFFFF';
         this.ctx.lineWidth = 2;
-        
+
         // Crosshair lines
         this.ctx.beginPath();
         // Top line
         this.ctx.moveTo(centerX, centerY - gap - size);
         this.ctx.lineTo(centerX, centerY - gap);
-        // Bottom line  
+        // Bottom line
         this.ctx.moveTo(centerX, centerY + gap);
         this.ctx.lineTo(centerX, centerY + gap + size);
         // Left line
@@ -359,10 +364,58 @@ class HUD {
         this.ctx.moveTo(centerX + gap, centerY);
         this.ctx.lineTo(centerX + gap + size, centerY);
         this.ctx.stroke();
-        
+
         // Center dot
         this.ctx.fillStyle = '#FFFFFF';
         this.ctx.fillRect(centerX - 1, centerY - 1, 2, 2);
+
+        // Hit marker overlay
+        const now = Date.now();
+        const elapsed = now - this.hitMarkerTime;
+        if (elapsed < this.hitMarkerDuration) {
+            const progress = elapsed / this.hitMarkerDuration;
+            const alpha = 1 - progress;
+            const expand = progress * 4; // slight expansion over time
+            const markerSize = 8 + expand;
+            const markerGap = 4 + expand;
+
+            // Color based on hit type
+            let color;
+            if (this.hitMarkerType === 'headshot') {
+                color = `rgba(255, 215, 0, ${alpha})`; // gold
+            } else if (this.hitMarkerType === 'critical') {
+                color = `rgba(255, 100, 0, ${alpha})`; // orange
+            } else {
+                color = `rgba(255, 255, 255, ${alpha})`; // white
+            }
+
+            this.ctx.strokeStyle = color;
+            this.ctx.lineWidth = 2;
+            this.ctx.beginPath();
+            // Top-left to center
+            this.ctx.moveTo(centerX - markerGap - markerSize, centerY - markerGap - markerSize);
+            this.ctx.lineTo(centerX - markerGap, centerY - markerGap);
+            // Top-right to center
+            this.ctx.moveTo(centerX + markerGap + markerSize, centerY - markerGap - markerSize);
+            this.ctx.lineTo(centerX + markerGap, centerY - markerGap);
+            // Bottom-left to center
+            this.ctx.moveTo(centerX - markerGap - markerSize, centerY + markerGap + markerSize);
+            this.ctx.lineTo(centerX - markerGap, centerY + markerGap);
+            // Bottom-right to center
+            this.ctx.moveTo(centerX + markerGap + markerSize, centerY + markerGap + markerSize);
+            this.ctx.lineTo(centerX + markerGap, centerY + markerGap);
+            this.ctx.stroke();
+        }
+    }
+
+    triggerHitMarker(type = 'normal') {
+        this.hitMarkerTime = Date.now();
+        this.hitMarkerType = type;
+
+        // Play hit marker sound
+        if (window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playHitMarker) {
+            window.soundEngine.playHitMarker(type);
+        }
     }
     
     loadWeaponImages() {

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -198,6 +198,12 @@ class Weapon {
                 window.game.hud.addDamageNumber(hit.enemy.x, hit.enemy.y, actualDamage, isCritical || isHeadshot, isHeadshot);
             }
 
+            // Hit marker
+            if (window.game && window.game.hud && window.game.hud.triggerHitMarker) {
+                const markerType = isHeadshot ? 'headshot' : (isCritical ? 'critical' : 'normal');
+                window.game.hud.triggerHitMarker(markerType);
+            }
+
             // Headshot sound
             if (isHeadshot && window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playHeadshot) {
                 window.soundEngine.playHeadshot();
@@ -570,6 +576,9 @@ class Weapon {
             if (window.game && window.game.hud) {
                 window.game.hud.emitBloodParticles(hit.enemy.x, hit.enemy.y, wasAlive && hit.enemy.dying ? 12 : 5);
                 window.game.hud.addDamageNumber(hit.enemy.x, hit.enemy.y, actualDamage, isCritical || isHeadshot, isHeadshot);
+                if (window.game.hud.triggerHitMarker) {
+                    window.game.hud.triggerHitMarker(isHeadshot ? 'headshot' : (isCritical ? 'critical' : 'normal'));
+                }
             }
             if (isHeadshot && window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playHeadshot) {
                 window.soundEngine.playHeadshot();
@@ -652,6 +661,9 @@ class Weapon {
             if (window.game && window.game.hud) {
                 window.game.hud.emitBloodParticles(hit.enemy.x, hit.enemy.y, 5);
                 window.game.hud.addDamageNumber(hit.enemy.x, hit.enemy.y, actualDamage, isCritical || isHeadshot, isHeadshot);
+                if (window.game.hud.triggerHitMarker) {
+                    window.game.hud.triggerHitMarker(isHeadshot ? 'headshot' : (isCritical ? 'critical' : 'normal'));
+                }
             }
         }
         if (hit.barrel && hit.barrel.active) {


### PR DESCRIPTION
## Summary
- Crosshair hit marker animation (X shape) when shots connect with enemies, with fade + expand effect
- Color-coded by hit type: white (normal), gold (headshot), orange (critical)
- Procedural "ping" hit marker sound via Web Audio API with pitch varying by type
- Wired into all fire paths: primary fire, alt-fire, and burst fire

## Test plan
- [x] All 43 existing tests pass
- [ ] Manually verify hit markers appear when shooting enemies
- [ ] Verify headshot markers are gold colored
- [ ] Verify hit marker sound is subtle and distinct from enemy hit sound

Fixes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)