### PR TITLE
Add enemy attack telegraph and knockback

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -515,6 +515,29 @@ class SoundEngine {
         oscillator.stop(now + 0.15);
     }
     
+    playAttackWarning() {
+        if (!this.isInitialized) return;
+
+        const now = this.audioContext.currentTime;
+
+        // Short ascending pitch warning chirp
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+
+        osc.type = 'square';
+        osc.frequency.setValueAtTime(400, now);
+        osc.frequency.linearRampToValueAtTime(800, now + 0.1);
+
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.15, now + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.12);
+
+        osc.start(now);
+        osc.stop(now + 0.12);
+    }
+
     playWeaponSwitch() {
         if (!this.isInitialized) return;
 

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -996,6 +996,21 @@ class Renderer {
             this.ctx.globalAlpha = 1.0;
             this.ctx.imageSmoothingEnabled = prevSmoothing;
 
+            // Attack telegraph overlay (orange pulse before melee attack)
+            if (!entity.dying && entity.attackTellTime) {
+                const tellElapsed = Date.now() - entity.attackTellTime;
+                const tellDuration = entity.attackTellDuration || 300;
+                if (tellElapsed < tellDuration) {
+                    // Pulsing orange glow that intensifies as attack approaches
+                    const progress = tellElapsed / tellDuration;
+                    const pulse = 0.2 + 0.3 * Math.sin(progress * Math.PI * 4) * progress;
+                    this.ctx.globalAlpha = pulse;
+                    this.ctx.fillStyle = '#FF6600';
+                    this.ctx.fillRect(spriteX, spriteY, spriteSize, adjustedHeight);
+                    this.ctx.globalAlpha = 1.0;
+                }
+            }
+
             // Hit flash overlay (red tint for 150ms after being hit)
             if (!entity.dying && entity.hitFlashTime && Date.now() - entity.hitFlashTime < 150) {
                 this.ctx.globalAlpha = 0.4;

--- a/js/entities/enemy-behaviors.js
+++ b/js/entities/enemy-behaviors.js
@@ -549,7 +549,6 @@ class EnhancedEnemyAI {
     
     performAttack(player) {
         if (this.hasLineOfSight(player, window.game.map)) {
-            this.enemy.tryBark('attack');
             let damage = this.behavior.damage;
 
             // Berserker rage: double damage when below 40% health
@@ -557,8 +556,9 @@ class EnhancedEnemyAI {
                 damage = Math.round(damage * 2);
             }
 
-            // Ranged enemies fire projectiles instead of hitscan
+            // Ranged enemies fire projectiles instead of hitscan (no telegraph needed)
             if (this.behavior.rangedAttack || this.behavior.strafeBehavior) {
+                this.enemy.tryBark('attack');
                 if (window.game && window.game.projectileManager) {
                     const speed = this.behavior.rangedAttack ? 150 : 200;
                     const color = this.behavior.rangedAttack ? '#44FF44' : '#FFAA00';
@@ -575,19 +575,40 @@ class EnhancedEnemyAI {
                 return;
             }
 
-            // Deal damage to player (with invincibility frame check)
-            if (player.takeDamage(damage)) {
-                // Trigger HUD damage flash
-                if (window.game && window.game.hud) {
-                    window.game.hud.onPlayerDamageFrom(this.enemy.x, this.enemy.y, damage);
-                }
+            // Melee attack with telegraph
+            const now = Date.now();
+            this.enemy.attackTellTime = now;
 
-                // Play attack and pain sounds
-                if (window.soundEngine && window.soundEngine.isInitialized) {
-                    this.playAttackSound();
-                    window.soundEngine.playPlayerHit();
-                }
+            // Warning sound
+            if (window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playAttackWarning) {
+                window.soundEngine.playAttackWarning();
             }
+
+            // Delay melee attack by telegraph duration
+            const tellDuration = this.enemy.attackTellDuration || 300;
+            const finalDamage = damage;
+            setTimeout(() => {
+                if (!this.enemy.active || this.enemy.dying) return;
+                const dist = this.getDistanceToPlayer(player);
+                if (dist > this.enemy.attackRange * 1.5) return;
+
+                this.enemy.tryBark('attack');
+
+                if (player.takeDamage(finalDamage)) {
+                    if (window.game && window.game.hud) {
+                        window.game.hud.onPlayerDamageFrom(this.enemy.x, this.enemy.y, finalDamage);
+                        window.game.hud.triggerScreenShake(8);
+                    }
+                    if (window.soundEngine && window.soundEngine.isInitialized) {
+                        this.playAttackSound();
+                        window.soundEngine.playPlayerHit();
+                    }
+                    // Melee knockback
+                    if (player.applyKnockback) {
+                        player.applyKnockback(this.enemy.x, this.enemy.y, 300);
+                    }
+                }
+            }, tellDuration);
         }
     }
     

--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -41,6 +41,10 @@ class Enemy {
         this.knockbackVX = 0;
         this.knockbackVY = 0;
 
+        // Attack telegraph
+        this.attackTellTime = 0; // timestamp when attack telegraph starts
+        this.attackTellDuration = 300; // ms of telegraph before attack lands
+
         // Death animation
         this.dying = false;
         this.deathTime = 0;
@@ -207,22 +211,45 @@ class Enemy {
     }
     
     attack(player) {
-        // Basic attack with cooldown
+        // Basic attack with cooldown and telegraph
         const now = Date.now();
         if (!this.lastAttackTime) this.lastAttackTime = 0;
 
         if (now - this.lastAttackTime > 2000) { // 2 second cooldown
-            this.tryBark('attack');
-            const damage = 15; // Default fallback damage
-            if (player.takeDamage(damage)) {
-                if (window.game && window.game.hud) {
-                    window.game.hud.onPlayerDamageFrom(this.x, this.y, damage);
+            // Start telegraph if not already telegraphing
+            if (!this.attackTellTime || now - this.attackTellTime > this.attackTellDuration) {
+                this.attackTellTime = now;
+
+                // Warning sound
+                if (window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playAttackWarning) {
+                    window.soundEngine.playAttackWarning();
                 }
-                if (window.soundEngine && window.soundEngine.isInitialized) {
-                    window.soundEngine.playPlayerHit();
-                }
+
+                // Delay the actual attack by telegraph duration
+                setTimeout(() => {
+                    if (!this.active || this.dying) return;
+                    const dist = this.getDistanceToPlayer(player);
+                    if (dist > this.attackRange * 1.5) return; // Player escaped
+
+                    this.tryBark('attack');
+                    const damage = 15;
+                    if (player.takeDamage(damage)) {
+                        if (window.game && window.game.hud) {
+                            window.game.hud.onPlayerDamageFrom(this.x, this.y, damage);
+                            window.game.hud.triggerScreenShake(8);
+                        }
+                        if (window.soundEngine && window.soundEngine.isInitialized) {
+                            window.soundEngine.playPlayerHit();
+                        }
+                        // Melee knockback
+                        if (player.applyKnockback) {
+                            player.applyKnockback(this.x, this.y, 300);
+                        }
+                    }
+                }, this.attackTellDuration);
+
+                this.lastAttackTime = now;
             }
-            this.lastAttackTime = now;
         }
     }
     


### PR DESCRIPTION
## Summary
- Enemies flash orange with pulsing intensity 300ms before melee attacks land
- Short ascending warning chirp sound plays during telegraph
- Melee attacks now push the player back (300 force knockback)
- Stronger screen shake (8) on melee hit vs normal hits
- Players can dodge telegraphed attacks by moving out of range
- Ranged enemies (spitters, soldiers) fire projectiles without telegraph

## Test plan
- [x] All 43 tests pass
- [x] Enemy flashes orange before melee attack
- [x] Warning sound audible before melee hit
- [x] Player pushed back on melee hit
- [x] Screen shakes harder on melee attacks

Fixes #148