### PR TITLE
Add enemy infighting mechanic

### DIFF
--- a/js/entities/enemy-behaviors.js
+++ b/js/entities/enemy-behaviors.js
@@ -195,7 +195,19 @@ class EnhancedEnemyAI {
     update(deltaTime, player, map, allEnemies) {
         // Update alert level
         this.updateAlertLevel(player);
-        
+
+        // Clear dead infight targets
+        if (this.enemy.infightTarget && (!this.enemy.infightTarget.active || this.enemy.infightTarget.dying)) {
+            this.enemy.infightTarget = null;
+        }
+
+        // Infighting: chase/attack the enemy that hit us
+        if (this.enemy.infightTarget) {
+            this.infightBehavior(deltaTime, map);
+            this.enhancedMovement(deltaTime, map, allEnemies);
+            return;
+        }
+
         // Behavior selection based on current state and behavior type
         switch (this.enemy.state) {
             case 'idle':
@@ -217,7 +229,7 @@ class EnhancedEnemyAI {
                 this.investigateBehavior(player, deltaTime, map);
                 break;
         }
-        
+
         // Apply movement with enhanced pathfinding
         this.enhancedMovement(deltaTime, map, allEnemies);
     }
@@ -547,6 +559,51 @@ class EnhancedEnemyAI {
         return { x: separationX, y: separationY };
     }
     
+    infightBehavior(deltaTime, map) {
+        const target = this.enemy.infightTarget;
+        const dx = target.x - this.enemy.x;
+        const dy = target.y - this.enemy.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+
+        if (distance < this.enemy.attackRange) {
+            // Attack the infight target
+            const now = Date.now();
+            if (now - this.lastAttackTime > this.behavior.attackCooldown) {
+                this.lastAttackTime = now;
+                let damage = this.behavior.damage;
+                if (this.behavior.berserkerRage && this.rageActive) {
+                    damage = Math.round(damage * 2);
+                }
+
+                this.enemy.tryBark('attack');
+
+                // Ranged enemies fire projectiles at infight target
+                if (this.behavior.rangedAttack || this.behavior.strafeBehavior) {
+                    if (window.game && window.game.projectileManager) {
+                        const speed = this.behavior.rangedAttack ? 150 : 200;
+                        const color = this.behavior.rangedAttack ? '#44FF44' : '#FFAA00';
+                        window.game.projectileManager.spawn(
+                            this.enemy.x, this.enemy.y,
+                            target.x, target.y,
+                            damage, speed, color, this.enemy
+                        );
+                    }
+                } else {
+                    // Melee attack on infight target
+                    target.takeDamage(damage, this.enemy);
+                    if (window.game && window.game.hud) {
+                        window.game.hud.addDamageNumber(target.x, target.y, damage, false);
+                        window.game.hud.emitBloodParticles(target.x, target.y, 5);
+                    }
+                }
+            }
+        } else {
+            // Chase the infight target
+            this.enemy.targetX = target.x;
+            this.enemy.targetY = target.y;
+        }
+    }
+
     performAttack(player) {
         if (this.hasLineOfSight(player, window.game.map)) {
             let damage = this.behavior.damage;

--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -49,7 +49,10 @@ class Enemy {
         this.dying = false;
         this.deathTime = 0;
         this.deathDuration = 600; // ms for death animation
-        
+
+        // Infighting: enemy that last damaged this enemy
+        this.infightTarget = null;
+
         // Enhanced AI system
         this.enhancedAI = null;
         if (window.EnhancedEnemyAI) {
@@ -100,8 +103,33 @@ class Enemy {
     
     originalUpdate(deltaTime, player, map) {
         const now = Date.now();
+
+        // Clear dead infight targets
+        if (this.infightTarget && (!this.infightTarget.active || this.infightTarget.dying)) {
+            this.infightTarget = null;
+        }
+
+        // Infighting: chase and attack the infight target instead of player
+        if (this.infightTarget) {
+            const target = this.infightTarget;
+            const dist = Math.sqrt((target.x - this.x) ** 2 + (target.y - this.y) ** 2);
+            if (dist < this.attackRange) {
+                if (!this.lastAttackTime || now - this.lastAttackTime > 2000) {
+                    this.lastAttackTime = now;
+                    target.takeDamage(15, this);
+                    if (window.game && window.game.hud) {
+                        window.game.hud.addDamageNumber(target.x, target.y, 15, false);
+                    }
+                }
+            } else {
+                this.targetX = target.x;
+                this.targetY = target.y;
+            }
+            return;
+        }
+
         const playerDistance = this.getDistanceToPlayer(player);
-        
+
         // State machine
         switch (this.state) {
             case 'idle':
@@ -278,17 +306,20 @@ class Enemy {
     }
     
     updateFacing(player) {
-        // Face towards player if chasing/attacking, otherwise face movement direction
+        // Face towards infight target if infighting, player if chasing/attacking, otherwise movement direction
         let targetX, targetY;
-        
-        if (this.state === 'chase' || this.state === 'attack') {
+
+        if (this.infightTarget && this.infightTarget.active && !this.infightTarget.dying) {
+            targetX = this.infightTarget.x;
+            targetY = this.infightTarget.y;
+        } else if (this.state === 'chase' || this.state === 'attack') {
             targetX = player.x;
             targetY = player.y;
         } else {
             targetX = this.targetX;
             targetY = this.targetY;
         }
-        
+
         this.angle = Math.atan2(targetY - this.y, targetX - this.x);
     }
     
@@ -329,7 +360,7 @@ class Enemy {
         }
     }
 
-    takeDamage(damage) {
+    takeDamage(damage, attacker) {
         let actualDamage = damage;
 
         // Front shield: reduce damage if hit from front
@@ -354,6 +385,12 @@ class Enemy {
 
         this.health -= actualDamage;
 
+        // Infighting: if damaged by another enemy, switch aggro target
+        if (attacker && attacker !== this && attacker.active && !attacker.dying) {
+            this.infightTarget = attacker;
+            this.state = 'chase';
+        }
+
         // Play hit sound
         if (window.soundEngine && window.soundEngine.isInitialized) {
             window.soundEngine.playEnemyHit();
@@ -368,7 +405,34 @@ class Enemy {
             this.dying = true;
             this.deathTime = Date.now();
             this.state = 'dying';
-            console.log(`${this.type} destroyed!`);
+
+            // Track infighting kill for player credit
+            const killedByEnemy = attacker && attacker.active;
+            if (killedByEnemy) {
+                console.log(`${this.type} killed by ${attacker.type} (infighting)!`);
+            } else {
+                console.log(`${this.type} destroyed!`);
+            }
+
+            // Player gets XP credit for infighting kills
+            if (killedByEnemy && window.game && window.game.player) {
+                const player = window.game.player;
+                const xpTable = { imp: 15, guard: 20, soldier: 30, demon: 40, berserker: 35, spitter: 25, shield_guard: 45, boss: 200 };
+                const xpReward = Math.round((xpTable[this.type] || 20) * 0.5); // Half XP for infighting kills
+                if (player.addXP) player.addXP(xpReward);
+                if (player.stats) player.stats.enemiesKilled++;
+                player.registerKill();
+
+                // Kill feed for infighting
+                if (window.game.hud && window.game.hud.addKillFeedMessage) {
+                    const victimName = (this.type || 'enemy').charAt(0).toUpperCase() + (this.type || 'enemy').slice(1);
+                    const killerName = (attacker.type || 'enemy').charAt(0).toUpperCase() + (attacker.type || 'enemy').slice(1);
+                    window.game.hud.addKillFeedMessage(`${killerName} killed ${victimName} +${xpReward} XP`, '#FF8800');
+                }
+
+                // Clear the attacker's infight target since victim is dead
+                attacker.infightTarget = null;
+            }
 
             // Play death sound
             if (window.soundEngine && window.soundEngine.isInitialized) {

--- a/js/entities/projectile.js
+++ b/js/entities/projectile.js
@@ -64,6 +64,26 @@ class Projectile {
                 }
             }
             this.active = false;
+            return;
+        }
+
+        // Check enemy collision (infighting - projectiles can hit other enemies)
+        if (window.game && window.game.map && window.game.map.enemies) {
+            for (const enemy of window.game.map.enemies) {
+                if (!enemy.active || enemy.dying) continue;
+                if (enemy === this.owner) continue; // Don't hit the enemy that fired it
+                const edx = this.x - enemy.x;
+                const edy = this.y - enemy.y;
+                const eDist = Math.sqrt(edx * edx + edy * edy);
+                if (eDist < this.radius + 16) { // 16 = enemy collision radius
+                    enemy.takeDamage(this.damage, this.owner);
+                    if (window.game && window.game.hud) {
+                        window.game.hud.addDamageNumber(enemy.x, enemy.y, this.damage, false);
+                    }
+                    this.active = false;
+                    return;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Enemy projectiles now collide with other enemies, triggering infighting
- Damaged enemies switch their aggro to the attacker and fight back
- Player earns half XP for infighting kills with distinct kill feed messages
- Works with both enhanced AI (ranged + melee attacks) and fallback AI

## Test plan
- [x] All 43 tests pass
- [x] T2-31 (ammo crate drops) still passes — `takeDamage` signature backward compatible
- [x] Enemy death/loot behavior unchanged for player kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)