### PR TITLE
Fix minimap player arrow rotation

### DIFF
--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -1978,16 +1978,17 @@ class HUD {
         this.ctx.closePath();
         this.ctx.fill();
 
+        this.ctx.restore();
+
         // Player direction indicator (triangle pointing up = forward)
+        // Drawn after restore so it stays fixed pointing up
         this.ctx.fillStyle = '#00FF00';
         this.ctx.beginPath();
-        this.ctx.moveTo(0, -6);
-        this.ctx.lineTo(-4, 4);
-        this.ctx.lineTo(4, 4);
+        this.ctx.moveTo(centerX, centerY - 6);
+        this.ctx.lineTo(centerX - 4, centerY + 4);
+        this.ctx.lineTo(centerX + 4, centerY + 4);
         this.ctx.closePath();
         this.ctx.fill();
-
-        this.ctx.restore();
 
         // Draw circular border (after restore so it's not rotated)
         this.ctx.strokeStyle = 'rgba(0, 255, 0, 0.4)';


### PR DESCRIPTION
## Summary
- Move player direction triangle drawing after `ctx.restore()` so it renders in screen space
- Arrow now always points up regardless of player facing direction

## Test plan
- [x] All 43 tests pass
- [x] Minimap arrow stays fixed pointing up when rotating

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)