### PR TITLE
Fix minimap FOV cone to match arrow behavior

### DIFF
--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -1969,15 +1969,19 @@ class HUD {
             this.ctx.fill();
         }
 
-        // Player is always at center, facing up
-        // Draw FOV cone (pointing up = forward in rotated space)
+        this.ctx.restore();
+
+        // Draw FOV cone (fixed pointing up, matching arrow behavior)
+        this.ctx.save();
+        this.ctx.beginPath();
+        this.ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+        this.ctx.clip();
         this.ctx.fillStyle = 'rgba(0, 255, 0, 0.08)';
         this.ctx.beginPath();
-        this.ctx.moveTo(0, 0);
-        this.ctx.arc(0, 0, radius * 0.8, -Math.PI / 2 - Math.PI / 6, -Math.PI / 2 + Math.PI / 6);
+        this.ctx.moveTo(centerX, centerY);
+        this.ctx.arc(centerX, centerY, radius * 0.8, -Math.PI / 2 - Math.PI / 6, -Math.PI / 2 + Math.PI / 6);
         this.ctx.closePath();
         this.ctx.fill();
-
         this.ctx.restore();
 
         // Player direction indicator (triangle pointing up = forward)


### PR DESCRIPTION
## Summary
- Moved the line-of-sight triangle (FOV cone) from inside the rotation transform to after `ctx.restore()`, so it stays fixed pointing up like the arrow indicator
- Previously the cone rotated with the map; now both indicators behave consistently in screen space

Fixes #177

## Test plan
- [x] All 43 tests pass
- [ ] Visually verify the FOV cone stays fixed pointing up while the map rotates underneath

🤖 Generated with [Claude Code](https://claude.com/claude-code)