### PR TITLE
Start wave counter immediately at Wave 1

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -184,6 +184,11 @@ class GameEngine {
         this.levelStartTime = performance.now();
         this.totalEnemyCount = this.map.enemies.length;
 
+        // Start wave system immediately — initial enemies are wave 1
+        this.waveSystem.active = true;
+        this.waveSystem.currentWave = 1;
+        this.waveSystem.state = 'fighting';
+
         // Initialize dynamic difficulty scaling
         this.initDifficultyScaler();
 
@@ -232,10 +237,10 @@ class GameEngine {
         this.levelStartTime = performance.now();
         this.totalEnemyCount = this.map.enemies.length;
 
-        // Reset wave system
-        this.waveSystem.active = false;
-        this.waveSystem.currentWave = 0;
-        this.waveSystem.state = 'idle';
+        // Reset wave system — start at wave 1 immediately
+        this.waveSystem.active = true;
+        this.waveSystem.currentWave = 1;
+        this.waveSystem.state = 'fighting';
 
         console.log('Level restarted');
     }
@@ -860,10 +865,10 @@ class GameEngine {
         this.totalEnemyCount = this.map.enemies.length;
         this.levelStartTime = performance.now();
 
-        // Reset wave system
-        this.waveSystem.active = false;
-        this.waveSystem.currentWave = 0;
-        this.waveSystem.state = 'idle';
+        // Reset wave system — start at wave 1 immediately
+        this.waveSystem.active = true;
+        this.waveSystem.currentWave = 1;
+        this.waveSystem.state = 'fighting';
 
         // Reset dynamic difficulty
         this.initDifficultyScaler();


### PR DESCRIPTION
## Summary
- Wave counter now shows "WAVE 1" from the moment the game starts
- Initial enemies are treated as Wave 1 instead of a pre-wave phase
- Applied to both game start and level restart

Fixes #178

## Test plan
- [x] All 43 tests pass
- [ ] Verify wave counter appears immediately on game start
- [ ] Verify wave 2 starts after clearing initial enemies

🤖 Generated with [Claude Code](https://claude.com/claude-code)