### PR TITLE
Add door to inaccessible Waste Storage room

### DIFF
--- a/js/world/map.js
+++ b/js/world/map.js
@@ -180,6 +180,7 @@ class GameMap {
         this.addDoor(12, 15, 'none');   // Reactor Core south entrance
         this.addDoor(20, 7, 'none');    // Containment Wing south exit
         this.addDoor(12, 18, 'red');    // Red key door to south section
+        this.addDoor(4, 18, 'none');     // Waste Storage entrance
     }
 
     addDoor(mapX, mapY, keyRequired) {


### PR DESCRIPTION
## Summary
- Identified Waste Storage room (cols 2-5, rows 19-22) as completely enclosed with no entry point
- Added a door at position (4, 18) on the north wall to provide access
- Flood-fill verified: all 360 open tiles now reachable from player spawn (16 were previously isolated)

Fixes #180

## Test plan
- [x] All 43 tests pass (T2-32 reports 6 doors, up from 5)
- [x] Flood-fill confirms 0 unreachable tiles
- [ ] Walk to Waste Storage room in-game and verify door opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)