### PR TITLE
Increase difficulty across all grades

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -445,9 +445,9 @@ class GameEngine {
         const diffSettings = window.DIFFICULTY ? window.DIFFICULTY[difficulty] : null;
 
         // Wave composition scales with wave number
-        const baseCount = 6 + Math.floor(waveNumber * 3);
-        const count = difficulty === 'nightmare' ? baseCount + 4 :
-                      difficulty === 'easy' ? Math.max(3, baseCount - 4) : baseCount;
+        const baseCount = 8 + Math.floor(waveNumber * 3.5);
+        const count = difficulty === 'nightmare' ? baseCount + 6 :
+                      difficulty === 'easy' ? Math.max(4, baseCount - 3) : baseCount;
 
         // Enemy types available per wave (harder types appear in later waves)
         const earlyTypes = ['guard', 'imp', 'exploder'];

--- a/js/main.js
+++ b/js/main.js
@@ -32,27 +32,27 @@ const CONFIG = {
 const DIFFICULTY = {
     easy: {
         label: 'Easy',
-        enemyHealthMultiplier: 0.6,
-        enemyDamageMultiplier: 0.5,
-        enemySpeedMultiplier: 0.8,
-        playerHealth: 150,
+        enemyHealthMultiplier: 0.8,
+        enemyDamageMultiplier: 0.7,
+        enemySpeedMultiplier: 0.9,
+        playerHealth: 125,
         extraEnemies: 0
     },
     normal: {
         label: 'Normal',
-        enemyHealthMultiplier: 1.0,
-        enemyDamageMultiplier: 1.0,
-        enemySpeedMultiplier: 1.0,
+        enemyHealthMultiplier: 1.2,
+        enemyDamageMultiplier: 1.3,
+        enemySpeedMultiplier: 1.1,
         playerHealth: 100,
         extraEnemies: 0
     },
     nightmare: {
         label: 'Nightmare',
-        enemyHealthMultiplier: 1.5,
-        enemyDamageMultiplier: 1.5,
-        enemySpeedMultiplier: 1.3,
+        enemyHealthMultiplier: 2.0,
+        enemyDamageMultiplier: 2.0,
+        enemySpeedMultiplier: 1.4,
         playerHealth: 75,
-        extraEnemies: 4
+        extraEnemies: 6
     }
 };
 


### PR DESCRIPTION
## Summary
- Bumped all difficulty multipliers to make the game more challenging
- **Easy**: 0.8x HP (was 0.6x), 0.7x DMG (was 0.5x), 0.9x SPD (was 0.8x), 125 player HP (was 150)
- **Normal**: 1.2x HP, 1.3x DMG, 1.1x SPD (all were 1.0x)
- **Nightmare**: 2.0x HP/DMG (were 1.5x), 1.4x SPD (was 1.3x), 6 extra enemies (was 4)
- Increased wave enemy base count from 6+3n to 8+3.5n

## Test plan
- [x] All 43 tests pass
- [x] Easy difficulty still gives >100 HP (test T2-22 verified at 125 HP)

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)