### PR TITLE
Fix pointer lock not released on menu screens

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -443,6 +443,10 @@ class GameEngine {
                     if (window.soundEngine && window.soundEngine.isInitialized) {
                         window.soundEngine.playLevelComplete();
                     }
+                    // Release pointer lock so player can click menu buttons
+                    if (document.pointerLockElement) {
+                        document.exitPointerLock();
+                    }
                     console.log(`Level ${this.currentLevel} complete! Score: ${this.currentScore}`);
                     return;
                 }
@@ -644,6 +648,10 @@ class GameEngine {
     onPlayerDeath() {
         this.showDeathScreen = true;
         this.deathScreenTime = performance.now();
+        // Release pointer lock so player can click menu buttons
+        if (document.pointerLockElement) {
+            document.exitPointerLock();
+        }
 
         // Calculate and save best run records
         const elapsed = (performance.now() - this.levelStartTime) / 1000;
@@ -1355,6 +1363,10 @@ class GameEngine {
     
     isPaused() {
         return this.paused;
+    }
+
+    isMenuOpen() {
+        return this.paused || this.levelComplete || this.showDeathScreen;
     }
     
     getCurrentState() {

--- a/js/engine/input.js
+++ b/js/engine/input.js
@@ -140,8 +140,8 @@ class InputManager {
     
     // Mouse event handlers
     onCanvasClick(event) {
-        // Don't request pointer lock while game is paused
-        if (!this.mouse.locked && !(window.game && window.game.isPaused())) {
+        // Don't request pointer lock while any menu is open
+        if (!this.mouse.locked && !(window.game && window.game.isMenuOpen())) {
             this.requestPointerLock();
         }
     }


### PR DESCRIPTION
## Summary
- Release pointer lock when level completion screen or death screen appears
- Add `isMenuOpen()` helper that covers all menu states (paused, level complete, death)
- Use `isMenuOpen()` in click handler to prevent re-acquiring pointer lock during any menu

## Test plan
- [x] All 43 tests pass
- [x] Pointer lock released on pause (existing), level complete (new), death (new)
- [x] Clicking during any menu screen does not re-acquire pointer lock

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)