### PR TITLE
Increase Reactor Overlord size by 25% and set HP to 750

### DIFF
--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -700,7 +700,7 @@ class Renderer {
         // Enemy type scale factors
         this.enemyScales = {
             imp: 0.6, guard: 0.7, soldier: 0.65, demon: 1.0,
-            berserker: 0.7, spitter: 0.55, shield_guard: 0.75, boss: 1.0,
+            berserker: 0.7, spitter: 0.55, shield_guard: 0.75, boss: 1.25,
             phantom: 0.6, exploder: 0.55, sniper: 0.6
         };
 

--- a/js/entities/enemy-behaviors.js
+++ b/js/entities/enemy-behaviors.js
@@ -202,7 +202,7 @@ const EnemyBehaviors = {
 
     // Boss enemy - massive health, multiple attack phases
     boss: {
-        health: 500,
+        health: 750,
         speed: 22,
         detectionRange: 500,
         attackRange: 150,


### PR DESCRIPTION
## Summary
- Increased boss sprite scale from 1.0 to 1.25 (+25%)
- Increased boss HP from 500 to 750

## Test plan
- [x] All 43 tests pass (T2-03 flaky, passes on retry)

Fixes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)