### PR TITLE
Minimap enemy blips: cloaking + scale-based sizing

### DIFF
--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -1984,16 +1984,21 @@ class HUD {
         }
 
         // Draw enemies
+        const enemyScales = { imp: 0.6, guard: 0.7, soldier: 0.65, demon: 1.0, berserker: 0.7, spitter: 0.55, shield_guard: 0.75, boss: 1.25, phantom: 0.6, exploder: 0.55, sniper: 0.6 };
         for (const enemy of map.enemies) {
             if (!enemy.active) continue;
+            // Hide cloaked phantoms (visible only when attacking)
+            if (enemy.cloaked) continue;
             const egx = Math.floor(enemy.x / map.tileSize);
             const egy = Math.floor(enemy.y / map.tileSize);
             if (!this.isTileRevealed(egx, egy)) continue;
             const rx = (enemy.x - player.x) * scale;
             const ry = (enemy.y - player.y) * scale;
             this.ctx.fillStyle = enemy.type === 'boss' ? '#FFD700' : '#FF4444';
+            const dotScale = enemyScales[enemy.type] || 0.6;
+            const dotRadius = Math.max(cellSize * 0.4 * (dotScale / 0.6), 2.5);
             this.ctx.beginPath();
-            this.ctx.arc(rx, ry, Math.max(cellSize * 0.4, 2.5), 0, Math.PI * 2);
+            this.ctx.arc(rx, ry, dotRadius, 0, Math.PI * 2);
             this.ctx.fill();
         }
 


### PR DESCRIPTION
## Summary
- Cloaked phantoms no longer show on minimap (only visible when attacking)
- Enemy blip size now scales proportionally to enemy type (bosses/demons larger, spitters/exploders smaller)
- Boss gold dots remain distinct

Fixes #208

## Test plan
- [x] All 43 tests pass
- [x] Phantom cloaking check added (`enemy.cloaked` skip)
- [x] Dot radius varies by enemy scale factor

🤖 Generated with [Claude Code](https://claude.com/claude-code)