### PR TITLE
Ammo counter polish: NO AMMO indicator and fix double-render

### DIFF
--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -376,21 +376,42 @@ class HUD {
         const weaponInfo = player.weaponManager.getHUDInfo();
         const x = this.canvas.width - 20;
         const y = this.canvas.height - 40;
-        
-        this.ctx.fillStyle = this.ammoColor;
-        this.ctx.font = this.largeFont;
-        this.ctx.textAlign = 'right';
-        this.ctx.fillText(weaponInfo.ammo, x, y);
-        
-        // Current ammo count (larger)
+
         const ammoText = weaponInfo.ammo.split('/');
         if (ammoText.length === 2) {
+            const clipAmmo = parseInt(ammoText[0]);
+            const reserveAmmo = parseInt(ammoText[1]);
+            const isEmpty = clipAmmo === 0;
+
+            // Clip ammo (large, red flash when empty)
+            this.ctx.textAlign = 'right';
+            if (isEmpty && !weaponInfo.isReloading) {
+                const flash = Math.sin(Date.now() * 0.008) > 0;
+                this.ctx.fillStyle = flash ? '#FF2222' : '#881111';
+            } else {
+                this.ctx.fillStyle = this.ammoColor;
+            }
             this.ctx.font = '32px monospace';
             this.ctx.fillText(ammoText[0], x - 80, y);
-            
+
+            // Separator and reserve
             this.ctx.font = this.font;
             this.ctx.fillStyle = this.textColor;
             this.ctx.fillText(`/ ${ammoText[1]}`, x - 20, y);
+
+            // "NO AMMO" indicator when completely out
+            if (isEmpty && reserveAmmo === 0 && !weaponInfo.isReloading) {
+                this.ctx.font = 'bold 14px monospace';
+                this.ctx.fillStyle = '#FF2222';
+                this.ctx.textAlign = 'right';
+                this.ctx.fillText('NO AMMO', x, y + 18);
+            }
+        } else {
+            // Fallback for non-standard ammo strings (e.g., punch)
+            this.ctx.fillStyle = this.ammoColor;
+            this.ctx.font = this.largeFont;
+            this.ctx.textAlign = 'right';
+            this.ctx.fillText(weaponInfo.ammo, x, y);
         }
     }
     


### PR DESCRIPTION
## Summary
- Fixed ammo counter double-render bug (was rendering full string then split version on top)
- Clip ammo now flashes red when magazine is empty
- "NO AMMO" indicator appears when both clip and reserve are depleted
- Fallback rendering for non-standard ammo strings (e.g., punch weapon)

Fixes #210

## Test plan
- [x] All 43 tests pass
- [x] Ammo counter renders cleanly without overlap
- [x] Red flash animation when clip is empty
- [x] "NO AMMO" text when completely out of ammo

🤖 Generated with [Claude Code](https://claude.com/claude-code)