### PR TITLE
Weapon sway and bob during movement

### DIFF
--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -17,6 +17,7 @@ class Player {
         this.currentTurnVelocity = 0; // Current keyboard turn velocity
         this.turnAcceleration = 12.0; // How fast turn ramps up (rad/s²)
         this.turnDeceleration = 10.0; // How fast turn ramps down (rad/s²)
+        this.lastTurnAmount = 0; // For weapon sway feedback
         this.lastFootstepTime = 0;
         this.footstepInterval = 400; // ms between footsteps
         
@@ -188,6 +189,7 @@ class Player {
             this.angle += turnAmount;
             this.angle = MathUtils.normalizeAngle(this.angle);
         }
+        this.lastTurnAmount = turnAmount;
     }
     
     handleMovement(inputManager, deltaTime) {

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -59,6 +59,9 @@ class HUD {
         this.weaponBobX = 0;
         this.weaponBobY = 0;
 
+        // Weapon sway (from mouse turning)
+        this.weaponSwayX = 0;
+
         // Damage direction indicators
         this.damageIndicators = [];
         this.damageIndicatorDuration = 1000; // 1 second
@@ -744,12 +747,22 @@ class HUD {
             if (Math.abs(this.weaponBobY) < 0.3) this.weaponBobY = 0;
         }
 
+        // Weapon sway (lateral offset from mouse turning)
+        if (!weaponInfo.isReloading) {
+            const turnAmount = player.lastTurnAmount || 0;
+            const swayTarget = Math.max(-20, Math.min(20, -turnAmount * 150));
+            this.weaponSwayX += (swayTarget - this.weaponSwayX) * 0.15;
+        } else {
+            this.weaponSwayX *= 0.9;
+        }
+        if (Math.abs(this.weaponSwayX) < 0.2) this.weaponSwayX = 0;
+
         // Weapon switch animation offset (slides weapon down off screen)
         const switchOffset = (weaponInfo.switchProgress || 0) * 250;
 
         // First-person weapon view (larger, bottom-right of screen)
         const fpsWeaponSize = 200;
-        const fpsX = this.canvas.width / 2 + 50 + this.weaponBobX;
+        const fpsX = this.canvas.width / 2 + 50 + this.weaponBobX + this.weaponSwayX;
         const fpsY = this.canvas.height - fpsWeaponSize + 20 - this.weaponRecoilOffset + this.weaponBobY + switchOffset;
 
         // Choose between gun and melee first-person sprite


### PR DESCRIPTION
## Summary
- Weapon sprite now sways left/right based on mouse turn speed
- Sway smoothly returns to center when not turning
- No sway during reload (weapon stays centered)
- Bob was already implemented; this adds the missing sway component

## Test plan
- [x] All 43 tests pass
- [ ] Verify weapon sprite moves laterally when turning with mouse
- [ ] Verify smooth return to center on stop

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)