### PR TITLE
Fix bestiary red hue for exploder and sniper

### DIFF
--- a/bestiary.html
+++ b/bestiary.html
@@ -164,7 +164,7 @@
                 <!-- Exploder -->
                 <div class="bestiary-card">
                     <div class="bestiary-portrait">
-                        <img src="assets/sprites/enemies/berserker_idle.png" alt="Exploder">
+                        <img src="assets/sprites/enemies/berserker_idle.png" alt="Exploder" style="filter: sepia(1) saturate(5) hue-rotate(-10deg) brightness(0.9);">
                     </div>
                     <div class="bestiary-info">
                         <h2 class="bestiary-name">Exploder</h2>
@@ -202,7 +202,7 @@
                 <!-- Sniper -->
                 <div class="bestiary-card">
                     <div class="bestiary-portrait">
-                        <img src="assets/sprites/enemies/soldier_idle.png" alt="Sniper">
+                        <img src="assets/sprites/enemies/soldier_idle.png" alt="Sniper" style="filter: sepia(1) saturate(5) hue-rotate(-10deg) brightness(0.9);">
                     </div>
                     <div class="bestiary-info">
                         <h2 class="bestiary-name">Sniper</h2>


### PR DESCRIPTION
## Summary
- Apply CSS red tint filter to exploder and sniper portraits on bestiary page
- Matches the in-game red-tinted appearance from `getRedTintedSprite`

## Test plan
- [x] All 43 tests pass
- [ ] Verify exploder/sniper portraits have red hue on bestiary page

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)