### PR TITLE
Weapon balancing: buff shotgun, nerf rifle

### DIFF
--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -38,18 +38,18 @@ class Weapon {
                 reloadTime: 2000 // 2 seconds
             },
             shotgun: {
-                damage: 60,
-                range: 200,
-                fireRate: 0.8, // slower fire rate
-                accuracy: 0.7,
+                damage: 90,
+                range: 250,
+                fireRate: 1.0, // pump action
+                accuracy: 0.75,
                 ammo: 8,
                 maxAmmo: 40,
-                reloadTime: 3000 // 3 seconds
+                reloadTime: 2800 // 2.8 seconds
             },
             rifle: {
-                damage: 35,
+                damage: 22,
                 range: 600,
-                fireRate: 4, // 4 shots per second
+                fireRate: 3, // 3 shots per second
                 accuracy: 0.95,
                 ammo: 30,
                 maxAmmo: 120,


### PR DESCRIPTION
## Summary
- **Shotgun**: damage 60→90, fire rate 0.8→1.0 rps, range 200→250, reload 3.0→2.8s
- **Rifle**: damage 35→22, fire rate 4→3 rps
- Shotgun now viable as high-damage close-range option (~90 DPS at close range)
- Rifle DPS reduced from ~133 to ~63, making it a precision tool rather than dominant pick

## Test plan
- [x] All 43 tests pass
- [ ] Verify shotgun feels impactful at close range
- [ ] Verify rifle still useful but not dominant

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)