### PR TITLE
Add screen shake on player damage

### DIFF
--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -741,6 +741,12 @@ class Player {
         this.stats.damageTaken += actualDamage;
         console.log(`Player took ${actualDamage} damage. Health: ${this.health}, Armor: ${this.armor}`);
 
+        // Screen shake proportional to damage taken
+        if (window.game && window.game.hud) {
+            const shakeAmount = Math.min(2 + actualDamage * 0.15, 12);
+            window.game.hud.triggerScreenShake(shakeAmount);
+        }
+
         if (this.health <= 0) {
             this.die();
         }


### PR DESCRIPTION
## Summary
- Screen shake now triggers when the player takes damage, with intensity proportional to damage amount
- Shake scales from 2 (light hit) to 12 (heavy hit) using formula: `min(2 + damage * 0.15, 12)`
- Integrates with existing `triggerScreenShake` (uses Math.max, so higher-intensity sources like exploder/barrel still override)

## Test plan
- [x] All 43 tests passing
- [x] Projectile hits now cause screen shake (was missing before)
- [x] Existing melee/explosion shake unaffected (Math.max takes higher value)

Fixes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)