### PR TITLE
Add weapon recoil and accuracy bloom

### DIFF
--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -486,28 +486,32 @@ class HUD {
         const weaponInfo = player && player.weaponManager ? player.weaponManager.getHUDInfo() : null;
         const weaponName = weaponInfo ? weaponInfo.weaponName : 'PISTOL';
         const isFiring = weaponInfo ? weaponInfo.muzzleFlash : false;
+        // Bloom spread expands crosshair gap (0-1 normalized)
+        const bloomFraction = weaponInfo && weaponInfo.bloomMax > 0
+            ? weaponInfo.bloomLevel / weaponInfo.bloomMax
+            : 0;
 
         this.ctx.strokeStyle = '#FFFFFF';
         this.ctx.lineWidth = 2;
 
         switch (weaponName) {
             case 'SHOTGUN':
-                this.drawShotgunCrosshair(centerX, centerY);
+                this.drawShotgunCrosshair(centerX, centerY, bloomFraction);
                 break;
             case 'RIFLE':
-                this.drawRifleCrosshair(centerX, centerY);
+                this.drawRifleCrosshair(centerX, centerY, bloomFraction);
                 break;
             case 'ROCKET':
                 this.drawRocketCrosshair(centerX, centerY);
                 break;
             case 'CHAINGUN':
-                this.drawChaingunCrosshair(centerX, centerY, isFiring);
+                this.drawChaingunCrosshair(centerX, centerY, isFiring, bloomFraction);
                 break;
             case 'PUNCH':
                 this.drawPunchCrosshair(centerX, centerY);
                 break;
             default: // PISTOL
-                this.drawPistolCrosshair(centerX, centerY);
+                this.drawPistolCrosshair(centerX, centerY, bloomFraction);
                 break;
         }
 
@@ -515,11 +519,11 @@ class HUD {
         this.renderHitMarker(centerX, centerY);
     }
 
-    drawPistolCrosshair(cx, cy) {
+    drawPistolCrosshair(cx, cy, bloomFraction = 0) {
         // Small precise dot with thin cross lines
         this.ctx.lineWidth = 1;
         const size = 6;
-        const gap = 4;
+        const gap = 4 + bloomFraction * 10;
         this.ctx.beginPath();
         this.ctx.moveTo(cx, cy - gap - size);
         this.ctx.lineTo(cx, cy - gap);
@@ -537,8 +541,8 @@ class HUD {
         this.ctx.fill();
     }
 
-    drawShotgunCrosshair(cx, cy) {
-        // Spread circle with tick marks showing spread area
+    drawShotgunCrosshair(cx, cy, bloomFraction = 0) {
+        // Spread circle with tick marks showing spread area (shotgun has no bloom)
         const radius = 16;
         this.ctx.lineWidth = 1.5;
         this.ctx.beginPath();
@@ -561,10 +565,10 @@ class HUD {
         this.ctx.fillRect(cx - 1, cy - 1, 2, 2);
     }
 
-    drawRifleCrosshair(cx, cy) {
+    drawRifleCrosshair(cx, cy, bloomFraction = 0) {
         // Tight precision cross with gap in center, thin lines
         this.ctx.lineWidth = 1;
-        const innerGap = 5;
+        const innerGap = 5 + bloomFraction * 8;
         const outerLen = 12;
         this.ctx.beginPath();
         // Top
@@ -610,7 +614,7 @@ class HUD {
         this.ctx.setLineDash([]);
     }
 
-    drawChaingunCrosshair(cx, cy, isFiring) {
+    drawChaingunCrosshair(cx, cy, isFiring, bloomFraction = 0) {
         // Rotating diagonal lines that spin while firing
         if (isFiring) {
             this.crosshairRotation += 0.3;
@@ -620,7 +624,7 @@ class HUD {
         }
         const rot = this.crosshairRotation;
         const size = 10;
-        const gap = 4;
+        const gap = 4 + bloomFraction * 14;
         this.ctx.lineWidth = 2;
         this.ctx.beginPath();
         for (let i = 0; i < 4; i++) {

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -22,6 +22,15 @@ class Weapon {
         this.muzzleFlashDuration = 100; // ms
         this.muzzleFlashStart = 0;
 
+        // Accuracy bloom (spread increases with consecutive shots)
+        const bloomStats = this.getBloomStats(type);
+        this.bloomLevel = 0; // Current bloom (0 = base accuracy, adds to spread)
+        this.bloomPerShot = bloomStats.bloomPerShot; // Bloom added per shot
+        this.bloomMax = bloomStats.bloomMax; // Maximum bloom
+        this.bloomDecayRate = bloomStats.bloomDecayRate; // Bloom decay per second
+        this.bloomDecayDelay = bloomStats.bloomDecayDelay; // ms before bloom starts decaying
+        this.lastShotTime = 0; // For bloom decay delay tracking
+
         // Weapon mods (upgrades)
         this.mods = [];
     }
@@ -79,7 +88,18 @@ class Weapon {
         
         return stats[type] || stats.pistol;
     }
-    
+
+    getBloomStats(type) {
+        const bloom = {
+            pistol: { bloomPerShot: 0.03, bloomMax: 0.12, bloomDecayRate: 0.3, bloomDecayDelay: 300 },
+            shotgun: { bloomPerShot: 0.0, bloomMax: 0.0, bloomDecayRate: 1.0, bloomDecayDelay: 0 },
+            rifle: { bloomPerShot: 0.02, bloomMax: 0.10, bloomDecayRate: 0.25, bloomDecayDelay: 250 },
+            rocket: { bloomPerShot: 0.0, bloomMax: 0.0, bloomDecayRate: 1.0, bloomDecayDelay: 0 },
+            chaingun: { bloomPerShot: 0.015, bloomMax: 0.20, bloomDecayRate: 0.15, bloomDecayDelay: 400 }
+        };
+        return bloom[type] || bloom.pistol;
+    }
+
     canFire() {
         const now = Date.now();
         const timeSinceLastShot = now - this.lastFireTime;
@@ -101,7 +121,11 @@ class Weapon {
         const now = Date.now();
         this.lastFireTime = now;
         this.ammo--;
-        
+
+        // Increase accuracy bloom
+        this.bloomLevel = Math.min(this.bloomLevel + this.bloomPerShot, this.bloomMax);
+        this.lastShotTime = now;
+
         // Muzzle flash effect
         this.muzzleFlash = true;
         this.muzzleFlashStart = now;
@@ -341,7 +365,11 @@ class Weapon {
         // Cast ray from player position in player's facing direction
         const rayX = player.x;
         const rayY = player.y;
-        const rayAngle = player.angle;
+        // Apply bloom spread: random angle offset within bloom cone
+        const bloomSpread = this.bloomLevel > 0
+            ? (Math.random() - 0.5) * 2 * this.bloomLevel
+            : 0;
+        const rayAngle = player.angle + bloomSpread;
         const rayDirX = Math.cos(rayAngle);
         const rayDirY = Math.sin(rayAngle);
         
@@ -487,6 +515,10 @@ class Weapon {
         const now = Date.now();
         this.lastFireTime = now;
         this.ammo -= altStats.ammoCost;
+
+        // Increase accuracy bloom
+        this.bloomLevel = Math.min(this.bloomLevel + this.bloomPerShot * (altStats.ammoCost || 1), this.bloomMax);
+        this.lastShotTime = now;
 
         // Muzzle flash
         this.muzzleFlash = true;
@@ -769,6 +801,11 @@ class Weapon {
         if (this.muzzleFlash && now - this.muzzleFlashStart >= this.muzzleFlashDuration) {
             this.muzzleFlash = false;
         }
+
+        // Decay accuracy bloom after delay (per-frame decay at ~60fps)
+        if (this.bloomLevel > 0 && now - this.lastShotTime > this.bloomDecayDelay) {
+            this.bloomLevel = Math.max(0, this.bloomLevel - this.bloomDecayRate * (1 / 60));
+        }
     }
     
     getKillXP(enemy) {
@@ -947,6 +984,8 @@ class WeaponManager {
             mods: weapon.mods,
             altFireLabel: altStats ? altStats.label : null,
             canAltFire: weapon.canAltFire(),
+            bloomLevel: weapon.bloomLevel,
+            bloomMax: weapon.bloomMax,
             switchProgress: this.switchProgress,
             isSwitching: this.switchState !== 'ready'
         };


### PR DESCRIPTION
## Summary
- Adds accuracy bloom system: consecutive shots increase spread, which recovers when not firing
- Per-weapon bloom tuning: pistol/rifle moderate, chaingun heavy accumulation, shotgun/rocket none
- Crosshairs visually expand/contract to reflect current bloom level
- Bloom spread applied to raycast angle for actual gameplay effect

## Test plan
- [x] All 43 tests pass
- [ ] Verify crosshair expands when firing pistol/rifle/chaingun rapidly
- [ ] Verify crosshair returns to normal after pausing fire
- [ ] Verify shotgun and rocket launcher are unaffected

Fixes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)