### PR TITLE
Add settings persistence with localStorage

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -141,6 +141,8 @@ class GameEngine {
             for (const item of this._pauseMenuItems) {
                 if (clickX >= item.x && clickX <= item.x + item.w &&
                     clickY >= item.y && clickY <= item.y + item.h) {
+                    // Determine if click was on left or right half for slider items
+                    const isLeftHalf = clickX < item.x + item.w / 2;
                     switch (item.action) {
                         case 'resume':
                             this.resume();
@@ -153,6 +155,27 @@ class GameEngine {
                                 window.soundEngine.toggleMusic();
                             }
                             break;
+                        case 'sensitivity': {
+                            const step = 0.001;
+                            const sens = window.CONFIG.input.mouseSensitivity;
+                            window.CONFIG.input.mouseSensitivity = isLeftHalf
+                                ? Math.max(0.001, sens - step)
+                                : Math.min(0.010, sens + step);
+                            if (window.saveSettings) window.saveSettings({ mouseSensitivity: window.CONFIG.input.mouseSensitivity });
+                            break;
+                        }
+                        case 'volume': {
+                            const volStep = 0.1;
+                            if (window.soundEngine) {
+                                const vol = window.soundEngine.masterVolume;
+                                const newVol = isLeftHalf
+                                    ? Math.max(0, vol - volStep)
+                                    : Math.min(1, vol + volStep);
+                                window.soundEngine.setMasterVolume(newVol);
+                                if (window.saveSettings) window.saveSettings({ masterVolume: newVol });
+                            }
+                            break;
+                        }
                     }
                     e.stopPropagation();
                     e.preventDefault();
@@ -1431,7 +1454,7 @@ class GameEngine {
 
         // Menu box
         const menuW = 300;
-        const menuH = 280;
+        const menuH = 340;
         const menuX = (w - menuW) / 2;
         const menuY = (h - menuH) / 2;
 
@@ -1447,15 +1470,22 @@ class GameEngine {
         ctx.textAlign = 'center';
         ctx.fillText('PAUSED', w / 2, menuY + 40);
 
+        // Current settings values
+        const sensitivity = window.CONFIG ? window.CONFIG.input.mouseSensitivity : 0.003;
+        const sensLabel = (sensitivity * 1000).toFixed(1);
+        const volume = window.soundEngine ? Math.round(window.soundEngine.masterVolume * 100) : 50;
+
         // Menu items
         const items = [
             { label: 'RESUME', action: 'resume' },
             { label: 'RESTART LEVEL', action: 'restart' },
-            { label: 'MUSIC: ' + (window.soundEngine && window.soundEngine.musicMuted ? 'OFF' : 'ON'), action: 'toggleMusic' }
+            { label: 'MUSIC: ' + (window.soundEngine && window.soundEngine.musicMuted ? 'OFF' : 'ON'), action: 'toggleMusic' },
+            { label: `SENSITIVITY: ${sensLabel}`, action: 'sensitivity' },
+            { label: `VOLUME: ${volume}%`, action: 'volume' }
         ];
 
-        const itemH = 45;
-        const itemStartY = menuY + 70;
+        const itemH = 40;
+        const itemStartY = menuY + 65;
         const mouseX = this.inputManager.mouse.x;
         const mouseY = this.inputManager.mouse.y;
 
@@ -1495,9 +1525,9 @@ class GameEngine {
 
         // Controls hint at bottom
         ctx.fillStyle = '#666666';
-        ctx.font = '12px monospace';
+        ctx.font = '11px monospace';
         ctx.textAlign = 'center';
-        ctx.fillText('ESC to resume | N to toggle music', w / 2, menuY + menuH - 15);
+        ctx.fillText('ESC resume | Click L/R to adjust settings', w / 2, menuY + menuH - 15);
     }
 
     // Event handling

--- a/js/engine/input.js
+++ b/js/engine/input.js
@@ -22,8 +22,8 @@ class InputManager {
             locked: false
         };
         
-        // Input settings
-        this.mouseSensitivity = 0.003;
+        // Input settings (read from CONFIG if available)
+        this.mouseSensitivity = (window.CONFIG && window.CONFIG.input.mouseSensitivity) || 0.003;
         this.keyRepeatDelay = 150;
         
         // Key mappings
@@ -238,9 +238,11 @@ class InputManager {
     }
     
     getMouseDelta() {
+        // Read sensitivity from CONFIG for live updates from pause menu
+        const sens = (window.CONFIG && window.CONFIG.input.mouseSensitivity) || this.mouseSensitivity;
         return {
-            x: this.mouse.deltaX * this.mouseSensitivity,
-            y: this.mouse.deltaY * this.mouseSensitivity
+            x: this.mouse.deltaX * sens,
+            y: this.mouse.deltaY * sens
         };
     }
     
@@ -285,7 +287,8 @@ class InputManager {
         
         // Mouse turning (if locked)
         if (this.mouse.locked) {
-            turn += this.mouse.deltaX * this.mouseSensitivity * 100; // Scale mouse input
+            const turnSens = (window.CONFIG && window.CONFIG.input.mouseSensitivity) || this.mouseSensitivity;
+            turn += this.mouse.deltaX * turnSens * 100; // Scale mouse input
         }
         
         return turn;

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,25 @@
 // Game instance
 let game = null;
 
+// Settings persistence key
+const SETTINGS_KEY = 'dailydoom_settings';
+
+function loadSettings() {
+    try {
+        const saved = localStorage.getItem(SETTINGS_KEY);
+        if (saved) return JSON.parse(saved);
+    } catch (e) { /* ignore */ }
+    return null;
+}
+
+function saveSettings(settings) {
+    try {
+        const current = loadSettings() || {};
+        Object.assign(current, settings);
+        localStorage.setItem(SETTINGS_KEY, JSON.stringify(current));
+    } catch (e) { /* ignore */ }
+}
+
 // Configuration
 const CONFIG = {
     canvas: {
@@ -67,22 +86,34 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
+    // Apply saved settings
+    const saved = loadSettings();
+    if (saved) {
+        if (saved.mouseSensitivity != null) CONFIG.input.mouseSensitivity = saved.mouseSensitivity;
+        if (saved.masterVolume != null) CONFIG.savedVolume = saved.masterVolume;
+    }
+
     // Setup canvas
     setupCanvas(canvas);
 
     // Setup resize handling
     setupResizeHandling(canvas);
 
-    // Setup difficulty selection
-    setupDifficultySelection(canvas);
+    // Setup difficulty selection (pass saved difficulty if available)
+    setupDifficultySelection(canvas, saved && saved.difficulty);
 });
 
-function setupDifficultySelection(canvas) {
+function setupDifficultySelection(canvas, savedDifficulty) {
     const overlay = document.getElementById('difficultyOverlay');
     if (!overlay) {
-        // No overlay found, start with default difficulty
-        startGame(canvas, 'normal');
+        startGame(canvas, savedDifficulty || 'normal');
         return;
+    }
+
+    // Highlight saved difficulty button
+    if (savedDifficulty) {
+        const savedBtn = overlay.querySelector(`[data-difficulty="${savedDifficulty}"]`);
+        if (savedBtn) savedBtn.style.outline = '2px solid #FFD700';
     }
 
     const buttons = overlay.querySelectorAll('.difficulty-btn');
@@ -90,6 +121,7 @@ function setupDifficultySelection(canvas) {
         btn.addEventListener('click', function() {
             const difficulty = btn.getAttribute('data-difficulty');
             overlay.classList.add('hidden');
+            saveSettings({ difficulty });
             startGame(canvas, difficulty);
         });
     });
@@ -110,6 +142,11 @@ function startGame(canvas, difficulty) {
 
         // Setup event listeners
         setupEventListeners();
+
+        // Apply saved volume
+        if (CONFIG.savedVolume != null && window.soundEngine) {
+            window.soundEngine.setMasterVolume(CONFIG.savedVolume);
+        }
 
         // Start the game
         game.start();
@@ -429,3 +466,4 @@ if (CONFIG.performance.enableProfiling) {
 window.CONFIG = CONFIG;
 window.DIFFICULTY = DIFFICULTY;
 window.applyDifficulty = applyDifficulty;
+window.saveSettings = saveSettings;


### PR DESCRIPTION
## Summary
- Difficulty, mouse sensitivity, and master volume saved to localStorage
- Settings automatically restored on page load
- Pause menu now includes sensitivity and volume controls (click left/right to adjust)
- Input manager reads sensitivity from CONFIG for live updates without restart

## Test plan
- [x] All 43 tests pass
- [ ] Verify settings persist after page reload
- [ ] Verify sensitivity/volume adjustable from pause menu
- [ ] Verify saved difficulty is highlighted on restart

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)