### PR TITLE
Add particle trail effects for projectiles

### DIFF
--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -1398,6 +1398,35 @@ class Renderer {
             // Center projectile vertically at half-wall height
             const projY = this.halfHeight;
 
+            // Render trail behind projectile
+            if (entity.trail && entity.trail.length > 0) {
+                const baseColor = entity.color || '#FF4400';
+                for (let i = 0; i < entity.trail.length; i++) {
+                    const tp = entity.trail[i];
+                    const tdx = tp.x - player.x;
+                    const tdy = tp.y - player.y;
+                    const tDist = Math.sqrt(tdx * tdx + tdy * tdy);
+                    if (tDist > this.maxRenderDistance || tDist < 1) continue;
+
+                    let tAngle = Math.atan2(tdy, tdx);
+                    let tAngleDiff = tAngle - player.angle;
+                    while (tAngleDiff > Math.PI) tAngleDiff -= MathUtils.PI2;
+                    while (tAngleDiff < -Math.PI) tAngleDiff += MathUtils.PI2;
+                    if (Math.abs(tAngleDiff) > this.fov / 2) continue;
+
+                    const tScreenX = this.width / 2 + (tAngleDiff / this.fov) * this.width;
+                    const tSize = Math.max(2, (this.wallHeight * this.projectionDistance) / tDist * 0.05);
+                    const alpha = (i + 1) / entity.trail.length * 0.6;
+
+                    this.ctx.globalAlpha = alpha;
+                    this.ctx.fillStyle = baseColor;
+                    this.ctx.beginPath();
+                    this.ctx.arc(tScreenX, this.halfHeight, tSize, 0, Math.PI * 2);
+                    this.ctx.fill();
+                }
+                this.ctx.globalAlpha = 1.0;
+            }
+
             // Glowing projectile circle
             this.ctx.fillStyle = entity.color || '#FF4400';
             this.ctx.beginPath();

--- a/js/entities/projectile.js
+++ b/js/entities/projectile.js
@@ -14,6 +14,12 @@ class Projectile {
         this.lifetime = 5000; // Max 5 seconds
         this.spawnTime = Date.now();
 
+        // Trail positions for visual effect
+        this.trail = [];
+        this.maxTrailLength = 6;
+        this.trailTimer = 0;
+        this.trailInterval = 0.02; // seconds between trail points
+
         // Calculate velocity toward target
         const dx = targetX - x;
         const dy = targetY - y;
@@ -34,6 +40,16 @@ class Projectile {
         if (Date.now() - this.spawnTime > this.lifetime) {
             this.active = false;
             return;
+        }
+
+        // Update trail
+        this.trailTimer += deltaTime;
+        if (this.trailTimer >= this.trailInterval) {
+            this.trailTimer = 0;
+            this.trail.push({ x: this.x, y: this.y, time: Date.now() });
+            if (this.trail.length > this.maxTrailLength) {
+                this.trail.shift();
+            }
         }
 
         // Move projectile


### PR DESCRIPTION
## Summary
- Projectiles (rockets, spitter acid, etc.) now leave fading particle trails
- Trail points stored per-projectile with configurable length (6 points)
- Rendered with distance-based perspective scaling and fade-out alpha
- No performance impact - lightweight trail point array per projectile

## Test plan
- [x] All 43 tests pass (0 failures)
- [ ] Verify enemy projectiles show visible trails when fired
- [ ] Confirm trails fade correctly and don't persist after projectile impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)