### PR TITLE
Update site stats and blog for Day 32

### DIFF
--- a/blog/entries.md
+++ b/blog/entries.md
@@ -4,6 +4,28 @@
 
 ---
 
+## Day 32 - March 21, 2026
+
+**"Sound and Fury"**
+
+Three improvements tonight focused on audio variety, visual feedback, and HUD clarity.
+
+- **Per-enemy-type death sounds** -- Each of the 11 enemy types now has a unique procedural death sound. Guards clang metallically, demons rumble with a deep guttural growl, phantoms fade with an ethereal whisper, and bosses get a dramatic multi-layered explosion. Slight pitch randomization (±10%) prevents repetitiveness even when killing the same type repeatedly.
+
+- **Projectile trail effects** -- Enemy projectiles (spitter acid, rockets) now leave fading particle trails as they fly, making projectile paths visible and combat more readable. Trail points are rendered with distance-based perspective scaling and alpha fade-out, matching the existing raycaster projection.
+
+- **Floor level indicator on HUD** -- The current dungeon floor number now displays next to the wave counter in the top-right HUD. Previously players had no way to know which floor they were on despite enemy stats scaling +15% per level. The blue "FLOOR X" text provides at-a-glance progression context.
+
+*Lines of code: 23,600*
+*Tests passing: 46*
+*Sprite assets: 66*
+*Enemy types: 11*
+*Tickets closed: 3*
+
+**Status: Kills feel unique with per-type audio, projectiles are easier to dodge with visible trails, and floor progression is finally visible.**
+
+---
+
 ## Day 31 - March 20, 2026
 
 **"Feel the Kick"**

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
                 <a href="#how-it-works" class="btn btn-secondary">How It Works</a>
             </div>
             <p class="hero-meta">
-                Day 31 &middot; 23,200 lines of code &middot; 46 tests passing &middot; 66 sprite assets
+                Day 32 &middot; 23,600 lines of code &middot; 46 tests passing &middot; 66 sprite assets
             </p>
         </div>
     </header>
@@ -218,7 +218,7 @@
             <h2 class="section-title">By the Numbers</h2>
             <div class="stats-grid">
                 <div class="stat">
-                    <div class="stat-value">23,200</div>
+                    <div class="stat-value">23,600</div>
                     <div class="stat-label">Lines of Code</div>
                 </div>
                 <div class="stat">


### PR DESCRIPTION
## Summary
- Updated hero meta and stats grid to Day 32 / 23,600 LOC
- Added Day 32 blog entry covering enemy death sounds, projectile trails, and floor level HUD

🤖 Generated with [Claude Code](https://claude.com/claude-code)