### PR TITLE
Improve enemy pain sounds with dedicated cooldown

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -1403,6 +1403,9 @@ class SoundEngine {
             berserker:   { freq: 200, type: 'sawtooth', duration: 0.2  },
             spitter:     { freq: 420, type: 'triangle', duration: 0.14 },
             shield_guard:{ freq: 250, type: 'triangle', duration: 0.2  },
+            phantom:     { freq: 600, type: 'sine',     duration: 0.1  },
+            exploder:    { freq: 380, type: 'square',   duration: 0.12 },
+            sniper:      { freq: 350, type: 'triangle', duration: 0.14 },
             boss:        { freq: 100, type: 'sawtooth', duration: 0.35 },
         };
         const p = params[enemyType] || params.guard;

--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -35,6 +35,8 @@ class Enemy {
         // Sound bark tracking
         this.lastBarkTime = 0;
         this.barkCooldown = 2000; // Minimum 2s between barks
+        this.lastPainTime = 0;
+        this.painCooldown = 500; // 0.5s between pain sounds
         this.hasPlayedAlert = false;
 
         // Knockback velocity (from explosions)
@@ -407,9 +409,15 @@ class Enemy {
             window.soundEngine.playEnemyHit();
         }
 
-        // Play pain bark (separate from hit/death sounds)
+        // Play pain sound with its own cooldown (separate from bark cooldown)
         if (this.health > 0) {
-            this.tryBark('pain');
+            const now2 = Date.now();
+            if (now2 - this.lastPainTime >= this.painCooldown) {
+                this.lastPainTime = now2;
+                if (window.soundEngine && window.soundEngine.isInitialized) {
+                    window.soundEngine.playEnemyPain(this.type);
+                }
+            }
         }
 
         if (this.health <= 0 && !this.dying) {


### PR DESCRIPTION
## Summary
- Pain sounds now have a separate 0.5s cooldown (was sharing 2s bark cooldown)
- Added pain sound profiles for phantom, exploder, and sniper (previously missing)
- Pain sounds fire directly from takeDamage instead of going through bark system
- Death sounds still take priority (pain skipped on killing blow)

## Test plan
- [x] All 43 Tier 1-2 tests passing
- [x] T2-34 (Enemy sound barks) passes — tryBark still works via bark system

Fixes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)