### PR TITLE
Add elite enemy variant system

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -542,6 +542,16 @@ class GameEngine {
             const type = typePool[Math.floor(Math.random() * typePool.length)];
             const enemy = new Enemy(spawnX, spawnY, type);
 
+            // Elite variant chance (wave 3+, never on bosses)
+            if (waveNumber >= 3 && type !== 'boss' && window.applyEliteVariant) {
+                const eliteChance = 0.15 + (waveNumber - 3) * 0.02 + (this.currentLevel - 1) * 0.03;
+                if (Math.random() < Math.min(eliteChance, 0.4)) {
+                    const variants = ['armored', 'enraged', 'regenerating'];
+                    const variant = variants[Math.floor(Math.random() * variants.length)];
+                    window.applyEliteVariant(enemy, variant);
+                }
+            }
+
             // Apply difficulty scaling
             if (diffSettings) {
                 enemy.health = Math.round(enemy.health * diffSettings.enemyHealthMultiplier);

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -867,6 +867,43 @@ class Renderer {
         return canvas;
     }
 
+    getEliteTintedSprite(baseSprite, type, state, tintColor) {
+        const key = `elite_${type}_${state}_${tintColor}`;
+        if (!this._eliteTintedSprites) this._eliteTintedSprites = {};
+        if (this._eliteTintedSprites[key]) return this._eliteTintedSprites[key];
+        if (!baseSprite) return null;
+
+        const w = baseSprite.width;
+        const h = baseSprite.height;
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        ctx.imageSmoothingEnabled = false;
+
+        // Draw original sprite
+        ctx.drawImage(baseSprite, 0, 0);
+
+        // Apply colored tint using 'multiply' composite
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.fillStyle = tintColor;
+        ctx.fillRect(0, 0, w, h);
+
+        // Brighten to make tint more visible
+        ctx.globalCompositeOperation = 'screen';
+        ctx.fillStyle = tintColor;
+        ctx.globalAlpha = 0.3;
+        ctx.fillRect(0, 0, w, h);
+        ctx.globalAlpha = 1.0;
+
+        // Restore alpha from original
+        ctx.globalCompositeOperation = 'destination-in';
+        ctx.drawImage(baseSprite, 0, 0);
+
+        this._eliteTintedSprites[key] = canvas;
+        return canvas;
+    }
+
     generateTintedSprites() {
         const baseSprite = this.sprites.imp;
         if (!baseSprite || !baseSprite.complete) return;
@@ -1212,6 +1249,13 @@ class Renderer {
                 } else {
                     sprite = upscaled;
                 }
+                // Apply elite variant tint
+                if (sprite && entity.isElite && entity.eliteType && window.EliteVariants) {
+                    const variantDef = window.EliteVariants[entity.eliteType];
+                    if (variantDef && variantDef.tintColor) {
+                        sprite = this.getEliteTintedSprite(sprite, enemyType + '_elite_' + entity.eliteType, spriteState, variantDef.tintColor);
+                    }
+                }
             }
             if (!sprite) {
                 sprite = this.tintedSprites[enemyType] || this.sprites.imp;
@@ -1291,7 +1335,7 @@ class Renderer {
             // Enemy health bar (shows above sprite after taking damage)
             if (!entity.dying && entity.health < entity.maxHealth) {
                 const isBoss = enemyType === 'boss';
-                const showAlways = isBoss && entity.state !== 'idle';
+                const showAlways = (isBoss || entity.isElite) && entity.state !== 'idle';
                 const timeSinceDamage = entity.lastDamageTime ? Date.now() - entity.lastDamageTime : Infinity;
                 const fadeTime = 2000; // 2 seconds before fade
 
@@ -1323,6 +1367,29 @@ class Renderer {
                         this.ctx.fillStyle = `rgb(${r}, ${g}, 0)`;
                     }
                     this.ctx.fillRect(barX, barY, barWidth * healthPct, barHeight);
+
+                    // Elite indicator: colored diamond above health bar
+                    if (entity.isElite && entity.eliteType && window.EliteVariants) {
+                        const variantDef = window.EliteVariants[entity.eliteType];
+                        if (variantDef) {
+                            const dSize = Math.max(4, barHeight * 2);
+                            const dX = barX + barWidth / 2;
+                            const dY = barY - dSize - 2;
+                            this.ctx.fillStyle = variantDef.tintColor;
+                            this.ctx.beginPath();
+                            this.ctx.moveTo(dX, dY - dSize / 2);
+                            this.ctx.lineTo(dX + dSize / 2, dY);
+                            this.ctx.lineTo(dX, dY + dSize / 2);
+                            this.ctx.lineTo(dX - dSize / 2, dY);
+                            this.ctx.closePath();
+                            this.ctx.fill();
+                            // Label
+                            this.ctx.font = `${Math.max(8, barHeight * 2)}px monospace`;
+                            this.ctx.textAlign = 'center';
+                            this.ctx.fillStyle = variantDef.tintColor;
+                            this.ctx.fillText(variantDef.label, dX, dY - dSize / 2 - 2);
+                        }
+                    }
 
                     this.ctx.globalAlpha = 1.0;
                 }

--- a/js/entities/enemy-behaviors.js
+++ b/js/entities/enemy-behaviors.js
@@ -957,6 +957,81 @@ class EnhancedEnemyAI {
     }
 }
 
+// Elite variant definitions
+const EliteVariants = {
+    armored: {
+        healthMult: 1.5,
+        speedMult: 0.9,
+        damageMult: 1.0,
+        resistanceOverride: null, // Uses base resistances but adds 0.5x to all non-explosive
+        tintColor: '#6688ff', // Blue tint
+        label: 'ARMORED'
+    },
+    enraged: {
+        healthMult: 0.75,
+        speedMult: 1.5,
+        damageMult: 1.5,
+        resistanceOverride: null,
+        tintColor: '#ff4444', // Bright red tint
+        label: 'ENRAGED'
+    },
+    regenerating: {
+        healthMult: 1.0,
+        speedMult: 1.0,
+        damageMult: 1.0,
+        regenRate: 5, // HP per second
+        resistanceOverride: null,
+        tintColor: '#44ff44', // Green tint
+        label: 'REGEN'
+    }
+};
+
+// Apply elite modifiers to an enemy after creation
+function applyEliteVariant(enemy, variantType) {
+    const variant = EliteVariants[variantType];
+    if (!variant) return;
+
+    enemy.isElite = true;
+    enemy.eliteType = variantType;
+
+    // Scale health
+    enemy.health = Math.round(enemy.health * variant.healthMult);
+    enemy.maxHealth = Math.round(enemy.maxHealth * variant.healthMult);
+
+    // Scale speed
+    enemy.speed = Math.round(enemy.speed * variant.speedMult);
+
+    // Scale damage via enhanced AI behavior
+    if (enemy.enhancedAI && enemy.enhancedAI.behavior) {
+        enemy.enhancedAI.behavior.damage = Math.round(
+            enemy.enhancedAI.behavior.damage * variant.damageMult
+        );
+    }
+
+    // Armored: add resistance to non-explosive weapons
+    if (variantType === 'armored' && enemy.enhancedAI && enemy.enhancedAI.behavior) {
+        const res = enemy.enhancedAI.behavior.resistances;
+        const armorTypes = ['pistol', 'rifle', 'chaingun', 'melee'];
+        for (const wt of armorTypes) {
+            if (!res[wt] || res[wt] >= 1.0) {
+                res[wt] = 0.5;
+            }
+        }
+    }
+
+    // Regenerating: store regen rate on enemy
+    if (variantType === 'regenerating') {
+        enemy.regenRate = variant.regenRate;
+    }
+
+    // Enraged: never flee
+    if (variantType === 'enraged' && enemy.enhancedAI && enemy.enhancedAI.behavior) {
+        enemy.enhancedAI.behavior.fleeHealthThreshold = 0;
+    }
+}
+
 // Export to global scope
 window.EnemyBehaviors = EnemyBehaviors;
 window.EnhancedEnemyAI = EnhancedEnemyAI;
+window.EliteVariants = EliteVariants;
+window.applyEliteVariant = applyEliteVariant;

--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -55,6 +55,11 @@ class Enemy {
         // Infighting: enemy that last damaged this enemy
         this.infightTarget = null;
 
+        // Elite variant properties
+        this.isElite = false;
+        this.eliteType = null;
+        this.regenRate = 0; // HP/sec for regenerating elites
+
         // Enhanced AI system
         this.enhancedAI = null;
         if (window.EnhancedEnemyAI) {
@@ -71,6 +76,11 @@ class Enemy {
                 this.active = false;
             }
             return; // No AI updates while dying
+        }
+
+        // Elite regeneration
+        if (this.regenRate > 0 && this.health < this.maxHealth) {
+            this.health = Math.min(this.maxHealth, this.health + this.regenRate * deltaTime);
         }
 
         // Use enhanced AI if available
@@ -437,7 +447,8 @@ class Enemy {
             if (killedByEnemy && window.game && window.game.player) {
                 const player = window.game.player;
                 const xpTable = { imp: 15, guard: 20, soldier: 30, demon: 40, berserker: 35, spitter: 25, shield_guard: 45, boss: 200, phantom: 30, exploder: 20, sniper: 35 };
-                const xpReward = Math.round((xpTable[this.type] || 20) * 0.5); // Half XP for infighting kills
+                const eliteBonus = this.isElite ? 1.5 : 1.0;
+                const xpReward = Math.round((xpTable[this.type] || 20) * 0.5 * eliteBonus); // Half XP for infighting kills, +50% for elites
                 if (player.addXP) player.addXP(xpReward);
                 if (player.stats) player.stats.enemiesKilled++;
                 player.registerKill();

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -593,15 +593,17 @@ class Player {
             if (wasAlive && !closestEnemy.active) {
                 if (this.stats) this.stats.enemiesKilled++;
                 const xpTable = { imp: 15, guard: 20, soldier: 30, demon: 40, berserker: 35, spitter: 25, shield_guard: 45, boss: 200 };
-                const xpReward = xpTable[closestEnemy.type] || 20;
+                const eliteBonus = closestEnemy.isElite ? 1.5 : 1.0;
+                const xpReward = Math.round((xpTable[closestEnemy.type] || 20) * eliteBonus);
                 if (this.addXP) this.addXP(xpReward);
                 this.registerKill();
 
                 // Kill feed message for punch kills
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (closestEnemy.type || 'enemy').charAt(0).toUpperCase() + (closestEnemy.type || 'enemy').slice(1);
+                    const eliteTag = closestEnemy.isElite ? ' [ELITE]' : '';
                     const comboText = isCombo ? 'COMBO! Punched' : 'Punched';
-                    window.game.hud.addKillFeedMessage(`${comboText} ${typeName} +${xpReward} XP`, isCombo ? '#FFD700' : '#FF4444');
+                    window.game.hud.addKillFeedMessage(`${comboText} ${typeName}${eliteTag} +${xpReward} XP`, isCombo ? '#FFD700' : '#FF4444');
                 }
             }
 

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -220,9 +220,10 @@ class Weapon {
                 // Kill feed message
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (hit.enemy.type || 'enemy').charAt(0).toUpperCase() + (hit.enemy.type || 'enemy').slice(1);
+                    const eliteTag = hit.enemy.isElite ? ' [ELITE]' : '';
                     const prefix = isHeadshot ? 'HEADSHOT! Killed' : (isCritical ? 'CRITICAL! Killed' : 'Killed');
                     const color = isHeadshot ? '#FFD700' : (isCritical ? '#FFD700' : '#FF4444');
-                    window.game.hud.addKillFeedMessage(`${prefix} ${typeName} +${xpReward} XP`, color);
+                    window.game.hud.addKillFeedMessage(`${prefix} ${typeName}${eliteTag} +${xpReward} XP`, color);
                 }
             }
 
@@ -642,8 +643,9 @@ class Weapon {
                 if (player.registerKill) player.registerKill();
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (hit.enemy.type || 'enemy').charAt(0).toUpperCase() + (hit.enemy.type || 'enemy').slice(1);
+                    const eliteTag = hit.enemy.isElite ? ' [ELITE]' : '';
                     const prefix = isHeadshot ? 'HEADSHOT!' : (isCritical ? 'CRITICAL!' : 'ALT!');
-                    window.game.hud.addKillFeedMessage(`${prefix} Killed ${typeName} +${xpReward} XP`, isHeadshot ? '#FFD700' : '#00CCFF');
+                    window.game.hud.addKillFeedMessage(`${prefix} Killed ${typeName}${eliteTag} +${xpReward} XP`, isHeadshot ? '#FFD700' : '#00CCFF');
                 }
             }
 
@@ -814,7 +816,9 @@ class Weapon {
             berserker: 35, spitter: 25, shield_guard: 45, boss: 200,
             phantom: 30, exploder: 20, sniper: 35
         };
-        return xpTable[enemy.type] || 20;
+        const baseXP = xpTable[enemy.type] || 20;
+        const eliteBonus = enemy.isElite ? 1.5 : 1.0;
+        return Math.round(baseXP * eliteBonus);
     }
 
     addMod(modType) {


### PR DESCRIPTION
## Summary
- Adds 3 elite variant types: **Armored** (blue, +50% HP, small arms resistance), **Enraged** (red, +50% speed/damage, -25% HP), **Regenerating** (green, 5 HP/sec regen)
- Elite enemies spawn in wave 3+ with 15-40% chance (scales with wave number and floor)
- Visual indicators: colored sprite tints, diamond icon + label above health bar, always-visible health bars
- +50% XP bonus for killing elites, shown in kill feed with [ELITE] tag
- Bosses cannot be elite variants

## Test plan
- [x] All 43 existing tests pass
- [ ] Verify elite enemies spawn visually in wave 3+
- [ ] Confirm armored (blue), enraged (red), regenerating (green) tints render correctly
- [ ] Check elite XP bonus appears in kill feed
- [ ] Verify regenerating enemies heal over time

Fixes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)