### PR TITLE
Add momentum multiplier system

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -47,6 +47,12 @@ class GameEngine {
         this.showDeathScreen = false;
         this.deathScreenTime = 0;
 
+        // Momentum multiplier (increases on wave clear, resets on death)
+        this.momentum = 1.0;
+        this.momentumMax = 3.0;
+        this.momentumStep = 0.2;
+        this.momentumLastChange = 0; // timestamp for HUD pulse animation
+
         // Dynamic difficulty scaling
         this.difficultyScaler = {
             lastCheckTime: 0,
@@ -248,6 +254,7 @@ class GameEngine {
         this.pauseMenuSelection = -1;
         this.levelComplete = false;
         this.levelCompleteTime = 0;
+        this.momentum = 1.0;
 
         // Re-initialize map and player
         this.map = new GameMap();
@@ -475,6 +482,15 @@ class GameEngine {
                 }
                 ws.lastWaveClearTime = now;
                 ws.state = 'waiting';
+
+                // Increase momentum multiplier on wave clear
+                if (this.momentum < this.momentumMax) {
+                    this.momentum = Math.min(this.momentumMax, this.momentum + this.momentumStep);
+                    this.momentumLastChange = performance.now();
+                    if (this.hud && this.hud.addKillFeedMessage) {
+                        this.hud.addKillFeedMessage(`MOMENTUM x${this.momentum.toFixed(1)}!`, '#FFAA00');
+                    }
+                }
             }
         }
     }
@@ -705,6 +721,11 @@ class GameEngine {
     onPlayerDeath() {
         this.showDeathScreen = true;
         this.deathScreenTime = performance.now();
+        // Reset momentum on death
+        if (this.momentum > 1.0) {
+            this.momentum = 1.0;
+            this.momentumLastChange = performance.now();
+        }
         // Release pointer lock so player can click menu buttons
         if (document.pointerLockElement) {
             document.exitPointerLock();
@@ -914,6 +935,7 @@ class GameEngine {
         console.log('Restarting level...');
         this.levelComplete = false;
         this.showDeathScreen = false;
+        this.momentum = 1.0;
 
         // Re-initialize map and enemies
         this.map = new GameMap();

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -978,7 +978,10 @@ class Player {
 
     // Progression methods
     addXP(amount) {
-        this.xp += amount;
+        // Apply momentum multiplier from game engine
+        const momentum = (window.game && window.game.momentum) || 1.0;
+        const scaledAmount = Math.round(amount * momentum);
+        this.xp += scaledAmount;
         while (this.xp >= this.xpToNextLevel) {
             this.xp -= this.xpToNextLevel;
             this.levelUp();

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -1651,11 +1651,37 @@ class HUD {
         const y = 45;
         const currentLevel = (window.game && window.game.currentLevel) || 1;
 
+        const momentum = (window.game && window.game.momentum) || 1.0;
+        const hasMomentum = momentum > 1.0;
+        const bgWidth = hasMomentum ? 260 : 192;
+
         ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
-        ctx.fillRect(x - 190, y - 14, 192, 20);
+        ctx.fillRect(x - bgWidth + 2, y - 14, bgWidth, 20);
 
         ctx.font = 'bold 14px monospace';
         ctx.textAlign = 'right';
+
+        // Momentum multiplier display
+        if (hasMomentum) {
+            const frac = (momentum - 1.0) / (((window.game && window.game.momentumMax) || 3.0) - 1.0);
+            let mColor;
+            if (frac < 0.25) mColor = '#FFFFFF';
+            else if (frac < 0.5) mColor = '#FFFF00';
+            else if (frac < 0.75) mColor = '#FFAA00';
+            else mColor = '#FF4444';
+
+            // Pulse animation on change
+            const lastChange = (window.game && window.game.momentumLastChange) || 0;
+            const pulseElapsed = performance.now() - lastChange;
+            if (pulseElapsed < 500) {
+                const scale = 1 + 0.15 * Math.sin(pulseElapsed / 500 * Math.PI);
+                ctx.font = `bold ${Math.round(14 * scale)}px monospace`;
+            }
+            ctx.fillStyle = mColor;
+            ctx.fillText(`x${momentum.toFixed(1)}`, x - 190, y);
+            ctx.font = 'bold 14px monospace';
+        }
+
         ctx.fillStyle = '#AAAAFF';
         ctx.fillText(`FLOOR ${currentLevel}`, x - 115, y);
         ctx.fillStyle = '#FF4444';


### PR DESCRIPTION
## Summary
- Momentum multiplier starts at 1.0x, increases +0.2x per wave cleared (max 3.0x)
- All XP scaled by current momentum multiplier
- Resets to 1.0x on death or full restart; persists across floor transitions
- HUD display with color gradient (white -> yellow -> orange -> red) and pulse animation

## Test plan
- [x] All 43 existing tests pass
- [ ] Verify multiplier increases after each wave clear
- [ ] Confirm multiplier resets on death
- [ ] Check HUD display updates correctly with color changes

Fixes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)