### PR TITLE
Auto-switch weapon when current runs empty

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -596,6 +596,28 @@ class SoundEngine {
         osc.stop(now + 0.08);
     }
 
+    // Dry-fire click (empty weapon)
+    playDryFire() {
+        if (!this.isInitialized) return;
+
+        const now = this.audioContext.currentTime;
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+
+        osc.type = 'square';
+        osc.frequency.setValueAtTime(300, now);
+        osc.frequency.setValueAtTime(150, now + 0.02);
+
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.15, now + 0.005);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.06);
+
+        osc.start(now);
+        osc.stop(now + 0.06);
+    }
+
     // Player pain/hit sound
     playPlayerHit() {
         if (!this.isInitialized) return;

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -769,6 +769,9 @@ class Weapon {
         if (this.isReloading || this.ammo === this.getWeaponStats(this.type).ammo) {
             return false; // Already reloading or full
         }
+        if (this.maxAmmo <= 0) {
+            return false; // No reserve ammo to reload from
+        }
         
         this.isReloading = true;
         this.reloadStartTime = Date.now();
@@ -934,7 +937,15 @@ class WeaponManager {
     
     fire(player, enemies, map) {
         if (this.switchState !== 'ready') return false;
-        return this.getCurrentWeapon().fire(player, enemies, map);
+        const weapon = this.getCurrentWeapon();
+        const result = weapon.fire(player, enemies, map);
+
+        // Auto-switch when weapon is completely empty (clip 0 + reserve 0)
+        if (weapon.ammo === 0 && weapon.maxAmmo === 0 && !weapon.isReloading) {
+            this.autoSwitchToAvailable();
+        }
+
+        return result;
     }
 
     altFire(player, enemies, map) {
@@ -945,7 +956,33 @@ class WeaponManager {
     reload() {
         return this.getCurrentWeapon().startReload();
     }
-    
+
+    /**
+     * Auto-switch to the best available weapon with ammo.
+     * Priority: rocket > chaingun > rifle > shotgun > pistol.
+     * Punch (melee) is always available as fallback but handled by player.
+     */
+    autoSwitchToAvailable() {
+        const priority = ['rocket', 'chaingun', 'rifle', 'shotgun', 'pistol'];
+        for (const wType of priority) {
+            if (wType === this.currentWeapon) continue;
+            if (!this.unlockedWeapons.has(wType)) continue;
+            const w = this.weapons[wType];
+            if (w.ammo > 0 || w.maxAmmo > 0) {
+                // Play dry-fire click before switching
+                if (window.soundEngine && window.soundEngine.isInitialized) {
+                    window.soundEngine.playDryFire();
+                }
+                this.switchWeapon(wType, true);
+                if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
+                    window.game.hud.addKillFeedMessage('OUT OF AMMO - switching weapon', '#FFAA00');
+                }
+                return true;
+            }
+        }
+        return false; // All weapons empty, player has punch
+    }
+
     update() {
         // Update all weapons (for reload timers, etc.)
         Object.values(this.weapons).forEach(weapon => weapon.update());


### PR DESCRIPTION
## Summary
- Automatically switches to best available weapon when current weapon has 0 clip and 0 reserve ammo
- Priority order: rocket > chaingun > rifle > shotgun > pistol (punch always available)
- Dry-fire click sound plays before the animated switch
- "OUT OF AMMO" message shown in kill feed
- Prevents pointless reload attempts when reserve ammo is 0

## Test plan
- [x] All 43 existing tests pass
- [ ] Verify auto-switch triggers when emptying a weapon completely
- [ ] Confirm dry-fire sound plays
- [ ] Check that manual weapon switching still works normally
- [ ] Verify reload still works when reserve ammo exists

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)