### PR TITLE
Add trap system with pressure plates and dart walls

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -1519,6 +1519,43 @@ class SoundEngine {
         osc.stop(now + 0.12);
     }
 
+    playTrapTrigger() {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Mechanical click
+        const click = this.audioContext.createOscillator();
+        const clickGain = this.audioContext.createGain();
+        click.connect(clickGain);
+        clickGain.connect(this.masterGain);
+        click.type = 'square';
+        click.frequency.setValueAtTime(600, now);
+        click.frequency.exponentialRampToValueAtTime(200, now + 0.05);
+        clickGain.gain.setValueAtTime(this.sfxVolume * 0.3, now);
+        clickGain.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
+        click.start(now);
+        click.stop(now + 0.08);
+
+        // Dart whoosh
+        const noiseBuffer = this.createNoiseBuffer(0.12);
+        if (noiseBuffer) {
+            const noise = this.audioContext.createBufferSource();
+            noise.buffer = noiseBuffer;
+            const filter = this.audioContext.createBiquadFilter();
+            filter.type = 'highpass';
+            filter.frequency.setValueAtTime(2000, now + 0.04);
+            const noiseGain = this.audioContext.createGain();
+            noise.connect(filter);
+            filter.connect(noiseGain);
+            noiseGain.connect(this.masterGain);
+            noiseGain.gain.setValueAtTime(0, now + 0.04);
+            noiseGain.gain.linearRampToValueAtTime(this.sfxVolume * 0.25, now + 0.06);
+            noiseGain.gain.exponentialRampToValueAtTime(0.001, now + 0.16);
+            noise.start(now + 0.04);
+            noise.stop(now + 0.16);
+        }
+    }
+
     playDash() {
         if (!this.isInitialized) return;
         const now = this.audioContext.currentTime;

--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -389,6 +389,9 @@ class GameEngine {
         // Update doors (proximity-based opening + animation)
         this.map.updateDoors(this.player.x, this.player.y, deltaTime);
 
+        // Update traps (pressure plates + dart walls)
+        this.map.updateTraps(deltaTime, this.player);
+
         // Hazard zone damage (acid: 5 HP/sec, lava: 8 HP/sec)
         const inAcid = this.map.isAcidAtPosition(this.player.x, this.player.y);
         const inLava = this.map.isLavaAtPosition(this.player.x, this.player.y);

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -1153,6 +1153,32 @@ class Renderer {
             });
         }
 
+        // Add pressure plates to rendering queue
+        if (this.map.pressurePlates) {
+            this.map.pressurePlates.forEach(plate => {
+                const dx = plate.x - player.x;
+                const dy = plate.y - player.y;
+                const distance = Math.sqrt(dx * dx + dy * dy);
+                if (distance > this.maxRenderDistance) return;
+
+                let plateAngle = Math.atan2(dy, dx);
+                let angleDiff = plateAngle - player.angle;
+                while (angleDiff > Math.PI) angleDiff -= MathUtils.PI2;
+                while (angleDiff < -Math.PI) angleDiff += MathUtils.PI2;
+                if (Math.abs(angleDiff) > this.fov / 2) return;
+                if (this.isOccludedByWall(player.x, player.y, plate.x, plate.y)) return;
+
+                spritesToRender.push({
+                    entity: plate,
+                    entityType: 'pressure_plate',
+                    distance: distance,
+                    angleDiff: angleDiff,
+                    x: plate.x,
+                    y: plate.y
+                });
+            });
+        }
+
         // Add projectiles to rendering queue
         if (window.game && window.game.projectileManager) {
             window.game.projectileManager.getActiveProjectiles().forEach(proj => {
@@ -1526,6 +1552,25 @@ class Renderer {
                 this.ctx.lineWidth = 1;
                 this.ctx.strokeRect(barrelX, barrelY, size, size);
             }
+        } else if (entityType === 'pressure_plate') {
+            // Flat diamond on the floor
+            const wallScreenHeight = (this.wallHeight * this.projectionDistance) / distance;
+            const floorY = this.halfHeight + wallScreenHeight / 2;
+            const plateSize = (this.wallHeight * this.projectionDistance) / distance * 0.25;
+            const plateColor = entity.triggered ? '#FF4400' : '#CCAA00';
+
+            this.ctx.fillStyle = plateColor;
+            this.ctx.beginPath();
+            this.ctx.moveTo(screenX, floorY - plateSize * 0.15);
+            this.ctx.lineTo(screenX - plateSize * 0.4, floorY);
+            this.ctx.lineTo(screenX, floorY + plateSize * 0.15);
+            this.ctx.lineTo(screenX + plateSize * 0.4, floorY);
+            this.ctx.closePath();
+            this.ctx.fill();
+
+            this.ctx.strokeStyle = '#555500';
+            this.ctx.lineWidth = 1;
+            this.ctx.stroke();
         }
     }
 }

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -2230,6 +2230,18 @@ class HUD {
             this.ctx.fill();
         }
 
+        // Draw pressure plates
+        if (map.pressurePlates) {
+            for (const plate of map.pressurePlates) {
+                if (!this.isTileRevealed(plate.tileX, plate.tileY)) continue;
+                const rx = (plate.x - player.x) * scale;
+                const ry = (plate.y - player.y) * scale;
+                this.ctx.fillStyle = plate.triggered ? '#FF4400' : '#CCAA00';
+                const s = Math.max(cellSize * 0.35, 2);
+                this.ctx.fillRect(rx - s / 2, ry - s / 2, s, s);
+            }
+        }
+
         this.ctx.restore();
 
         // Draw FOV cone (fixed pointing up, matching arrow behavior)
@@ -2300,6 +2312,7 @@ class HUD {
             { color: 'rgba(255, 100, 0, 0.8)', label: 'Lava' },
             { color: '#886600', label: 'Door' },
             { color: '#00CCFF', label: 'Pickup' },
+            { color: '#CCAA00', label: 'Trap' },
         ];
 
         // Background

--- a/js/world/map.js
+++ b/js/world/map.js
@@ -45,6 +45,8 @@ class GameMap {
         this.secretsFound = 0;
         this.totalSecrets = 0;
         this.weaponPickups = [];
+        this.pressurePlates = [];
+        this.dartTraps = [];
 
         // Initialize from theme data
         if (theme) {
@@ -124,6 +126,36 @@ class GameMap {
                 this.addSecretWall(s.wallX, s.wallY, s.roomX, s.roomY);
             }
             console.log(`Secret rooms initialized: ${this.totalSecrets} secrets`);
+        }
+
+        // Traps: pressure plates linked to dart walls
+        if (theme.traps) {
+            for (const trap of theme.traps) {
+                const plate = {
+                    x: trap.plateX * this.tileSize + this.tileSize / 2,
+                    y: trap.plateY * this.tileSize + this.tileSize / 2,
+                    tileX: trap.plateX,
+                    tileY: trap.plateY,
+                    radius: 24,
+                    triggered: false,
+                    cooldown: 0,
+                    cooldownTime: 3000, // ms before can trigger again
+                    dartTrapIndex: this.dartTraps.length
+                };
+                const dart = {
+                    x: trap.dartX * this.tileSize + this.tileSize / 2,
+                    y: trap.dartY * this.tileSize + this.tileSize / 2,
+                    direction: trap.direction, // 'north','south','east','west'
+                    damage: 15,
+                    speed: 250,
+                    active: true
+                };
+                this.pressurePlates.push(plate);
+                this.dartTraps.push(dart);
+            }
+            if (this.pressurePlates.length > 0) {
+                console.log(`Traps initialized: ${this.pressurePlates.length} pressure plates`);
+            }
         }
     }
 
@@ -435,6 +467,81 @@ class GameMap {
             if (window.game.hud && window.game.hud.addKillFeedMessage) {
                 window.game.hud.addKillFeedMessage('Crate destroyed!', '#C8A030');
             }
+        }
+    }
+
+    // --- Trap methods ---
+
+    updateTraps(deltaTime, player) {
+        const now = performance.now();
+        for (const plate of this.pressurePlates) {
+            // Decrease cooldown
+            if (plate.cooldown > 0) {
+                plate.cooldown -= deltaTime * 1000;
+                if (plate.cooldown <= 0) {
+                    plate.cooldown = 0;
+                    plate.triggered = false;
+                }
+                continue;
+            }
+
+            // Check if player is on the plate
+            const pdx = player.x - plate.x;
+            const pdy = player.y - plate.y;
+            let stepped = (pdx * pdx + pdy * pdy) < plate.radius * plate.radius;
+
+            // Check if any enemy is on the plate
+            if (!stepped) {
+                for (const enemy of this.enemies) {
+                    if (!enemy.active || enemy.dying) continue;
+                    const edx = enemy.x - plate.x;
+                    const edy = enemy.y - plate.y;
+                    if ((edx * edx + edy * edy) < plate.radius * plate.radius) {
+                        stepped = true;
+                        break;
+                    }
+                }
+            }
+
+            if (stepped && !plate.triggered) {
+                plate.triggered = true;
+                plate.cooldown = plate.cooldownTime;
+                this.fireDartTrap(plate.dartTrapIndex);
+            }
+        }
+    }
+
+    fireDartTrap(index) {
+        const trap = this.dartTraps[index];
+        if (!trap || !trap.active) return;
+
+        // Calculate target position based on direction
+        const dist = this.tileSize * 20; // fire across the map
+        let targetX = trap.x;
+        let targetY = trap.y;
+        switch (trap.direction) {
+            case 'north': targetY -= dist; break;
+            case 'south': targetY += dist; break;
+            case 'east':  targetX += dist; break;
+            case 'west':  targetX -= dist; break;
+        }
+
+        // Spawn dart projectile
+        if (window.game && window.game.projectileManager) {
+            window.game.projectileManager.spawn(
+                trap.x, trap.y, targetX, targetY,
+                trap.damage, trap.speed, '#FF8800', null
+            );
+        }
+
+        // Trap trigger sound
+        if (window.soundEngine && window.soundEngine.isInitialized) {
+            window.soundEngine.playTrapTrigger();
+        }
+
+        // Particle burst at dart origin
+        if (window.game && window.game.hud) {
+            window.game.hud.emitExplosionParticles(trap.x, trap.y, 4);
         }
     }
 

--- a/js/world/themes.js
+++ b/js/world/themes.js
@@ -122,6 +122,12 @@ const MapThemes = {
             { type: 'weapon_rifle', x: 1.5, y: 12.5 },
             { type: 'weapon_rocket', x: 12.5, y: 14.5 },
             { type: 'weapon_chaingun', x: 20.5, y: 11.5 }
+        ],
+        traps: [
+            // Corridor between control room and reactor — plate in hallway, dart from north wall
+            { plateX: 12, plateY: 8, dartX: 12, dartY: 7, direction: 'south' },
+            // South corridor near waste storage — plate triggers dart from east
+            { plateX: 8, plateY: 17, dartX: 9, dartY: 17, direction: 'west' }
         ]
     },
 
@@ -240,6 +246,12 @@ const MapThemes = {
             { type: 'weapon_rifle', x: 1.5, y: 12.5 },
             { type: 'weapon_rocket', x: 12.5, y: 12.5 },
             { type: 'weapon_chaingun', x: 20.5, y: 11.5 }
+        ],
+        traps: [
+            // Main road ambush — plate mid-road, dart from north
+            { plateX: 12, plateY: 9, dartX: 12, dartY: 8, direction: 'south' },
+            // South corridor near bunker — plate triggers dart from east wall
+            { plateX: 7, plateY: 16, dartX: 8, dartY: 16, direction: 'west' }
         ]
     },
 
@@ -358,6 +370,12 @@ const MapThemes = {
             { type: 'weapon_rifle', x: 1.5, y: 11.5 },
             { type: 'weapon_rocket', x: 14.5, y: 11.5 },
             { type: 'weapon_chaingun', x: 20.5, y: 9.5 }
+        ],
+        traps: [
+            // Main tunnel crossing — plate in tunnel, dart from south wall
+            { plateX: 10, plateY: 7, dartX: 10, dartY: 8, direction: 'north' },
+            // South passage — plate in corridor, dart from west wall
+            { plateX: 4, plateY: 15, dartX: 3, dartY: 15, direction: 'east' }
         ]
     },
 
@@ -476,6 +494,12 @@ const MapThemes = {
             { type: 'weapon_rifle', x: 2.5, y: 11.5 },
             { type: 'weapon_rocket', x: 12.5, y: 11.5 },
             { type: 'weapon_chaingun', x: 20.5, y: 11.5 }
+        ],
+        traps: [
+            // Entry cavern corridor — plate in open area, dart from south
+            { plateX: 7, plateY: 7, dartX: 7, dartY: 8, direction: 'north' },
+            // South passage near altar — plate triggers dart from east
+            { plateX: 7, plateY: 16, dartX: 8, dartY: 16, direction: 'west' }
         ]
     },
 
@@ -594,6 +618,12 @@ const MapThemes = {
             { type: 'weapon_rifle', x: 1.5, y: 12.5 },
             { type: 'weapon_rocket', x: 12.5, y: 12.5 },
             { type: 'weapon_chaingun', x: 20.5, y: 11.5 }
+        ],
+        traps: [
+            // Frozen corridor — plate mid-corridor, dart from south
+            { plateX: 12, plateY: 9, dartX: 12, dartY: 8, direction: 'south' },
+            // South observation area — plate triggers dart from east
+            { plateX: 7, plateY: 16, dartX: 8, dartY: 16, direction: 'west' }
         ]
     }
 };


### PR DESCRIPTION
## Summary
- Pressure plates on the floor trigger linked dart wall traps when stepped on by players or enemies
- 2 traps per map placed in corridors across all 5 themes
- 3D rendered diamond-shaped floor markers (yellow=idle, red=triggered)
- Mechanical click + whoosh sound effect on trigger, 3-second cooldown
- Minimap shows pressure plate locations, legend includes Trap entry

## Test plan
- [x] All 43 existing tests pass
- [ ] Verify pressure plates visible in 3D view and on minimap
- [ ] Verify stepping on plate fires dart projectile
- [ ] Verify darts can hit both players and enemies
- [ ] Verify 3-second cooldown between triggers

Fixes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)