### PR TITLE
Add footstep sounds with surface-aware variation

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -491,34 +491,58 @@ class SoundEngine {
         }
     }
     
-    // Footstep sounds
-    playFootstep() {
+    // Footstep sounds with surface-aware variation
+    playFootstep(surfaceType = 'stone') {
         if (!this.isInitialized) return;
-        
+
         const now = this.audioContext.currentTime;
-        const noiseBuffer = this.createNoiseBuffer(0.05); // Very short
+
+        // Surface profiles: filterFreq, filterQ, volume, duration, addTone
+        const surfaces = {
+            metal:  { freq: 800, Q: 6, vol: 0.25, dur: 0.06, tone: 4200 },
+            stone:  { freq: 200, Q: 2, vol: 0.20, dur: 0.05, tone: 0 },
+            ice:    { freq: 1200, Q: 8, vol: 0.18, dur: 0.04, tone: 6000 },
+            liquid: { freq: 400, Q: 1, vol: 0.22, dur: 0.08, tone: 0 }
+        };
+        const s = surfaces[surfaceType] || surfaces.stone;
+
+        // Slight random pitch variation for natural feel
+        const pitchVar = 0.85 + Math.random() * 0.3;
+
+        const noiseBuffer = this.createNoiseBuffer(s.dur);
         const noiseSource = this.audioContext.createBufferSource();
         const gainNode = this.audioContext.createGain();
         const filterNode = this.audioContext.createBiquadFilter();
-        
-        // Set up audio chain
+
         noiseSource.buffer = noiseBuffer;
         noiseSource.connect(filterNode);
         filterNode.connect(gainNode);
         gainNode.connect(this.masterGain);
-        
-        // Filter for more realistic footstep
+
         filterNode.type = 'lowpass';
-        filterNode.frequency.setValueAtTime(200, now);
-        filterNode.Q.setValueAtTime(2, now);
-        
-        // Quick envelope
+        filterNode.frequency.setValueAtTime(s.freq * pitchVar, now);
+        filterNode.Q.setValueAtTime(s.Q, now);
+
         gainNode.gain.setValueAtTime(0, now);
-        gainNode.gain.linearRampToValueAtTime(this.sfxVolume * 0.2, now + 0.01);
-        gainNode.gain.exponentialRampToValueAtTime(0.001, now + 0.05);
-        
+        gainNode.gain.linearRampToValueAtTime(this.sfxVolume * s.vol, now + 0.008);
+        gainNode.gain.exponentialRampToValueAtTime(0.001, now + s.dur);
+
         noiseSource.start(now);
-        noiseSource.stop(now + 0.05);
+        noiseSource.stop(now + s.dur);
+
+        // Metal and ice get a brief tonal click for that sharp tap sound
+        if (s.tone > 0) {
+            const osc = this.audioContext.createOscillator();
+            const oscGain = this.audioContext.createGain();
+            osc.connect(oscGain);
+            oscGain.connect(this.masterGain);
+            osc.type = 'sine';
+            osc.frequency.setValueAtTime(s.tone * pitchVar, now);
+            oscGain.gain.setValueAtTime(this.sfxVolume * 0.06, now);
+            oscGain.gain.exponentialRampToValueAtTime(0.001, now + 0.025);
+            osc.start(now);
+            osc.stop(now + 0.025);
+        }
     }
     
     // Reload sound

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -370,10 +370,12 @@ class Player {
         // Check for footsteps (if player moved significantly)
         const distanceMoved = Math.sqrt((this.x - originalX) ** 2 + (this.y - originalY) ** 2);
         const now = Date.now();
-        
-        if (distanceMoved > 2 && now - this.lastFootstepTime > this.footstepInterval) {
+        const stepInterval = this.isSprinting ? 280 : this.footstepInterval;
+
+        if (distanceMoved > 2 && now - this.lastFootstepTime > stepInterval) {
             if (window.soundEngine && window.soundEngine.isInitialized) {
-                window.soundEngine.playFootstep();
+                const surface = this.getSurfaceType(map);
+                window.soundEngine.playFootstep(surface);
                 this.lastFootstepTime = now;
             }
         }
@@ -1013,6 +1015,25 @@ class Player {
 
     getXPProgress() {
         return this.xp / this.xpToNextLevel;
+    }
+
+    getSurfaceType(map) {
+        if (!map) return 'stone';
+        const tx = Math.floor(this.x / 64);
+        const ty = Math.floor(this.y / 64);
+        // Liquid overrides everything
+        if (map.isAcidTile && map.isAcidTile(tx, ty)) return 'liquid';
+        if (map.isLavaTile && map.isLavaTile(tx, ty)) return 'liquid';
+        // Zone-based surface mapping
+        const profile = map.getZoneAudioProfile ? map.getZoneAudioProfile(tx, ty) : 'corridor';
+        const profileToSurface = {
+            control: 'metal',
+            reactor: 'metal',
+            cooling: 'ice',
+            waste: 'stone',
+            corridor: 'stone'
+        };
+        return profileToSurface[profile] || 'stone';
     }
 
     // Debug methods


### PR DESCRIPTION
## Summary
- Footstep sounds now vary by surface type: metal, stone, ice, and liquid
- Surface determined from zone audio profile and acid/lava tile checks
- Sprint cadence faster (280ms vs 400ms interval)
- Random pitch variation for natural feel

## Test plan
- [x] All 43 tests passing
- [ ] Verify footstep sounds play when moving
- [ ] Verify different sound profiles in different zones

Fixes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)