### PR TITLE
Add boss special attacks (charge, slam, summon)

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -1748,6 +1748,90 @@ class SoundEngine {
         osc.stop(now + 0.3);
     }
 
+    // Boss special attack sounds
+    playBossTelegraph(attackType) {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+
+        // Rising warning tone
+        osc.type = 'sawtooth';
+        if (attackType === 'charge') {
+            osc.frequency.setValueAtTime(100, now);
+            osc.frequency.linearRampToValueAtTime(300, now + 0.6);
+        } else if (attackType === 'slam') {
+            osc.frequency.setValueAtTime(60, now);
+            osc.frequency.linearRampToValueAtTime(200, now + 0.6);
+        } else {
+            osc.frequency.setValueAtTime(200, now);
+            osc.frequency.linearRampToValueAtTime(600, now + 0.6);
+        }
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.35, now + 0.1);
+        gain.gain.setValueAtTime(this.sfxVolume * 0.35, now + 0.5);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.7);
+        osc.start(now);
+        osc.stop(now + 0.7);
+    }
+
+    playBossSlam() {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Deep impact thud
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(50, now);
+        osc.frequency.exponentialRampToValueAtTime(15, now + 0.4);
+        gain.gain.setValueAtTime(this.sfxVolume * 0.7, now);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.5);
+        osc.start(now);
+        osc.stop(now + 0.5);
+
+        // Noise crunch
+        const nb = this.createNoiseBuffer(0.2);
+        if (nb) {
+            const noise = this.audioContext.createBufferSource();
+            noise.buffer = nb;
+            const ng = this.audioContext.createGain();
+            const filter = this.audioContext.createBiquadFilter();
+            noise.connect(filter);
+            filter.connect(ng);
+            ng.connect(this.masterGain);
+            filter.type = 'lowpass';
+            filter.frequency.setValueAtTime(300, now);
+            ng.gain.setValueAtTime(this.sfxVolume * 0.5, now);
+            ng.gain.exponentialRampToValueAtTime(0.001, now + 0.25);
+            noise.start(now);
+            noise.stop(now + 0.25);
+        }
+    }
+
+    playBossSummon() {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Eerie descending tone
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+        osc.type = 'triangle';
+        osc.frequency.setValueAtTime(500, now);
+        osc.frequency.exponentialRampToValueAtTime(100, now + 0.5);
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.4, now + 0.05);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.6);
+        osc.start(now);
+        osc.stop(now + 0.6);
+    }
+
     playExplosion() {
         if (!this.isInitialized) return;
         const now = this.audioContext.currentTime;

--- a/js/entities/enemy-behaviors.js
+++ b/js/entities/enemy-behaviors.js
@@ -210,7 +210,7 @@ const EnemyBehaviors = {
         sniperRelocate: true // Relocates after firing
     },
 
-    // Boss enemy - massive health, multiple attack phases
+    // Boss enemy - massive health, multiple attack phases, special attacks
     boss: {
         health: 750,
         speed: 22,
@@ -229,7 +229,8 @@ const EnemyBehaviors = {
         useCover: false,
         chargeAttack: true,
         bossPhases: true, // Changes behavior at health thresholds
-        summonMinions: true // Spawns additional enemies
+        summonMinions: true, // Spawns additional enemies
+        bossSpecialAttacks: true // Charge rush, ground slam, periodic summon
     }
 };
 
@@ -427,6 +428,13 @@ class EnhancedEnemyAI {
         // Boss phase transitions
         if (this.behavior.bossPhases) {
             this.updateBossPhase(player, map);
+        }
+
+        // Boss special attacks (checked before normal attack)
+        if (this.behavior.bossSpecialAttacks) {
+            if (this.updateBossSpecialAttack(player, deltaTime, map)) {
+                return; // Special attack in progress, skip normal attack
+            }
         }
 
         // Check if should retreat to maintain distance
@@ -938,6 +946,198 @@ class EnhancedEnemyAI {
                 console.log('Boss summoned a minion!');
             }
         }
+    }
+
+    // Boss special attack system
+    updateBossSpecialAttack(player, deltaTime, map) {
+        const now = Date.now();
+        if (!this.bossSpecialCooldown) this.bossSpecialCooldown = 0;
+        if (!this.bossSpecialState) this.bossSpecialState = 'idle'; // idle, telegraph, executing
+
+        // Handle active special attack execution
+        if (this.bossSpecialState === 'executing') {
+            return this.executeBossSpecial(player, deltaTime, map);
+        }
+
+        // Telegraph phase: boss is winding up
+        if (this.bossSpecialState === 'telegraph') {
+            if (now - this.bossSpecialTelegraphStart >= 800) {
+                this.bossSpecialState = 'executing';
+                this.bossSpecialExecStart = now;
+            }
+            return true; // Block normal attacks during telegraph
+        }
+
+        // Check cooldown for next special
+        const specialInterval = this.bossPhase === 3 ? 6000 : this.bossPhase === 2 ? 8000 : 10000;
+        if (now - this.bossSpecialCooldown < specialInterval) return false;
+
+        // Pick a special attack
+        const distance = this.getDistanceToPlayer(player);
+        const phase = this.bossPhase || 1;
+        let specials = [];
+
+        // Ground slam: close range
+        if (distance < 200) specials.push('slam');
+        // Charge rush: medium-far range
+        if (distance > 100 && distance < 400) specials.push('charge');
+        // Summon: phase 2+, prefer when few minions alive
+        if (phase >= 2 && map) {
+            const minionCount = map.enemies.filter(e => e.active && !e.dying && e.type !== 'boss').length;
+            if (minionCount < 4) specials.push('summon');
+        }
+
+        if (specials.length === 0) return false;
+
+        // Start telegraph
+        this.bossCurrentSpecial = specials[Math.floor(Math.random() * specials.length)];
+        this.bossSpecialState = 'telegraph';
+        this.bossSpecialTelegraphStart = now;
+        this.bossSpecialCooldown = now;
+        this.enemy.bossSpecialTelegraph = this.bossCurrentSpecial; // for HUD
+
+        // Telegraph sound
+        if (window.soundEngine && window.soundEngine.isInitialized) {
+            window.soundEngine.playBossTelegraph(this.bossCurrentSpecial);
+        }
+
+        return true;
+    }
+
+    executeBossSpecial(player, deltaTime, map) {
+        const now = Date.now();
+        const elapsed = now - this.bossSpecialExecStart;
+        const special = this.bossCurrentSpecial;
+
+        if (special === 'charge') {
+            return this.executeBossCharge(player, deltaTime, map, elapsed);
+        } else if (special === 'slam') {
+            return this.executeBossSlam(player, deltaTime, map, elapsed);
+        } else if (special === 'summon') {
+            return this.executeBossSummon(player, map, elapsed);
+        }
+
+        this.endBossSpecial();
+        return false;
+    }
+
+    executeBossCharge(player, deltaTime, map, elapsed) {
+        const chargeDuration = 600;
+        if (elapsed >= chargeDuration) {
+            this.endBossSpecial();
+            return false;
+        }
+
+        // Rush toward player at 3x speed
+        const chargeSpeed = this.behavior.speed * 3;
+        const dx = player.x - this.enemy.x;
+        const dy = player.y - this.enemy.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+
+        if (dist > 10) {
+            const moveX = (dx / dist) * chargeSpeed * deltaTime;
+            const moveY = (dy / dist) * chargeSpeed * deltaTime;
+            if (map && !map.isWallAtPosition(this.enemy.x + moveX, this.enemy.y)) {
+                this.enemy.x += moveX;
+            }
+            if (map && !map.isWallAtPosition(this.enemy.x, this.enemy.y + moveY)) {
+                this.enemy.y += moveY;
+            }
+        }
+
+        // Check collision with player
+        if (dist < 50) {
+            const chargeDamage = 50;
+            if (player.takeDamage(chargeDamage)) {
+                if (window.game && window.game.hud) {
+                    window.game.hud.onPlayerDamageFrom(this.enemy.x, this.enemy.y, chargeDamage);
+                    window.game.hud.triggerScreenShake(15);
+                    window.game.hud.addKillFeedMessage('BOSS CHARGE!', '#FF4400');
+                }
+                if (player.applyKnockback) {
+                    player.applyKnockback(this.enemy.x, this.enemy.y, 600);
+                }
+                if (window.soundEngine && window.soundEngine.isInitialized) {
+                    window.soundEngine.playPlayerHit();
+                }
+            }
+            this.endBossSpecial();
+            return false;
+        }
+
+        return true;
+    }
+
+    executeBossSlam(player, deltaTime, map, elapsed) {
+        if (elapsed >= 200) {
+            // Slam executes instantly after brief delay
+            const distance = this.getDistanceToPlayer(player);
+            const slamRadius = 160;
+            const slamDamage = 35;
+
+            if (distance < slamRadius) {
+                // Damage falls off with distance
+                const falloff = 1 - (distance / slamRadius);
+                const damage = Math.round(slamDamage * falloff);
+                if (player.takeDamage(damage)) {
+                    if (window.game && window.game.hud) {
+                        window.game.hud.onPlayerDamageFrom(this.enemy.x, this.enemy.y, damage);
+                        window.game.hud.addKillFeedMessage('BOSS SLAM!', '#FF8800');
+                    }
+                    if (player.applyKnockback) {
+                        player.applyKnockback(this.enemy.x, this.enemy.y, 400);
+                    }
+                }
+            }
+
+            // Visual + audio
+            if (window.game && window.game.hud) {
+                window.game.hud.triggerScreenShake(20);
+                window.game.hud.emitBloodParticles(this.enemy.x, this.enemy.y, 10);
+            }
+            if (window.soundEngine && window.soundEngine.isInitialized) {
+                window.soundEngine.playBossSlam();
+            }
+
+            this.endBossSpecial();
+            return false;
+        }
+        return true;
+    }
+
+    executeBossSummon(player, map, elapsed) {
+        if (elapsed >= 300) {
+            const count = (this.bossPhase || 1) >= 3 ? 3 : 2;
+            for (let i = 0; i < count; i++) {
+                const angle = (i / count) * Math.PI * 2 + Math.random() * 0.5;
+                const spawnX = this.enemy.x + Math.cos(angle) * 90;
+                const spawnY = this.enemy.y + Math.sin(angle) * 90;
+                if (map && !map.isWallAtPosition(spawnX, spawnY)) {
+                    const type = Math.random() < 0.5 ? 'imp' : 'guard';
+                    const minion = new Enemy(spawnX, spawnY, type);
+                    minion.state = 'chase';
+                    map.enemies.push(minion);
+                }
+            }
+
+            if (window.game && window.game.hud) {
+                window.game.hud.addKillFeedMessage('BOSS SUMMONS MINIONS!', '#FF00FF');
+                window.game.hud.triggerScreenShake(6);
+            }
+            if (window.soundEngine && window.soundEngine.isInitialized) {
+                window.soundEngine.playBossSummon();
+            }
+
+            this.endBossSpecial();
+            return false;
+        }
+        return true;
+    }
+
+    endBossSpecial() {
+        this.bossSpecialState = 'idle';
+        this.bossCurrentSpecial = null;
+        this.enemy.bossSpecialTelegraph = null;
     }
 
     findFleeTarget(player, map) {

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -228,6 +228,9 @@ class HUD {
             // Render hazard zone warning
             this.renderHazardWarning();
 
+            // Render boss attack telegraph warning
+            this.renderBossAttackWarning(gameEngine);
+
             this.ctx.restore();
         } catch (error) {
             console.error('HUD: Critical rendering error:', error);
@@ -1321,6 +1324,34 @@ class HUD {
         const textAlpha = 0.6 + 0.4 * Math.sin(now * 0.006);
         this.ctx.fillStyle = `rgba(${color}, ${textAlpha})`;
         this.ctx.fillText(`WARNING: ${label} ZONE`, w / 2, h - 52);
+        this.ctx.textAlign = 'left';
+    }
+
+    renderBossAttackWarning(gameEngine) {
+        if (!gameEngine || !gameEngine.map) return;
+        const boss = gameEngine.map.enemies.find(e => e.active && !e.dying && e.type === 'boss' && e.bossSpecialTelegraph);
+        if (!boss) return;
+
+        const now = Date.now();
+        const w = this.canvas.width;
+        const h = this.canvas.height;
+        const pulse = 0.5 + 0.5 * Math.sin(now * 0.015);
+
+        // Red border flash
+        const edgeSize = 8;
+        this.ctx.fillStyle = `rgba(255, 50, 0, ${0.3 * pulse})`;
+        this.ctx.fillRect(0, 0, w, edgeSize);
+        this.ctx.fillRect(0, h - edgeSize, w, edgeSize);
+        this.ctx.fillRect(0, 0, edgeSize, h);
+        this.ctx.fillRect(w - edgeSize, 0, edgeSize, h);
+
+        // Warning text
+        const labels = { charge: 'BOSS CHARGING!', slam: 'GROUND SLAM!', summon: 'SUMMONING!' };
+        const label = labels[boss.bossSpecialTelegraph] || 'BOSS ATTACK!';
+        this.ctx.font = 'bold 22px monospace';
+        this.ctx.textAlign = 'center';
+        this.ctx.fillStyle = `rgba(255, ${Math.floor(80 * pulse)}, 0, ${0.6 + 0.4 * pulse})`;
+        this.ctx.fillText(label, w / 2, 80);
         this.ctx.textAlign = 'left';
     }
 


### PR DESCRIPTION
## Summary
- Boss enemies now have 3 special attack types: charge rush, ground slam, and summon minions
- 800ms telegraph phase with visual HUD warning and audio cue before each special
- Special cooldowns scale with boss phase (10s/8s/6s)
- Each attack has distinct sound effects and visual feedback

## Test plan
- [x] 42/43 tests passing (T2-03 known flaky)
- [ ] Verify boss telegraph warning appears on HUD
- [ ] Verify charge, slam, and summon attacks trigger in gameplay

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)