### PR TITLE
Fix renderer crash from invalid projectile color

### DIFF
--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -1427,9 +1427,6 @@ class Renderer {
                 const pulse = 0.4 + 0.3 * Math.sin(Date.now() * 0.006);
                 const glowSize = size * 1.8;
                 const glowColor = entity.properties.color || '#FFD700';
-                const grad = this.ctx.createRadialGradient(screenX, screenY, size * 0.2, screenX, screenY, glowSize / 2);
-                grad.addColorStop(0, glowColor.replace(')', `, ${pulse})`).replace('rgb', 'rgba').replace('#', ''));
-                // Simpler approach: use globalAlpha
                 this.ctx.save();
                 this.ctx.globalAlpha = pulse;
                 this.ctx.fillStyle = glowColor;

--- a/js/entities/projectile.js
+++ b/js/entities/projectile.js
@@ -7,6 +7,9 @@ class Projectile {
         this.y = y;
         this.damage = damage;
         this.speed = speed;
+        if (color && !color.startsWith('#')) {
+            color = '#' + color;
+        }
         this.color = color || '#FF4400';
         this.owner = owner; // Reference to the enemy that fired it
         this.active = true;


### PR DESCRIPTION
## Summary
- Remove unused radial gradient code with broken hex-to-rgba conversion that stripped the `#` prefix from color values, causing `addColorStop()` to throw a `SyntaxError`
- The power-up glow effect already uses the simpler `globalAlpha` approach directly below
- Add defensive `#` prefix validation in `Projectile` constructor to prevent similar issues

Fixes #289

## Test plan
- [x] All 43 tests pass
- [x] Power-up glow rendering still works (uses globalAlpha path)
- [x] Projectile colors with missing # prefix are auto-corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)