### PR TITLE
Add Glory Kill melee finishers on low-health enemies

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -1342,6 +1342,57 @@ class SoundEngine {
         noiseSource.stop(now + 0.12);
     }
 
+    playGloryKill() {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        // Heavy impact bass
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(100, now);
+        osc.frequency.exponentialRampToValueAtTime(25, now + 0.25);
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.9, now + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+        osc.start(now);
+        osc.stop(now + 0.3);
+
+        // Crunch noise burst
+        const noiseBuffer = this.createNoiseBuffer(0.15);
+        const noiseSource = this.audioContext.createBufferSource();
+        const noiseGain = this.audioContext.createGain();
+        const filter = this.audioContext.createBiquadFilter();
+        noiseSource.buffer = noiseBuffer;
+        noiseSource.connect(filter);
+        filter.connect(noiseGain);
+        noiseGain.connect(this.masterGain);
+        filter.type = 'bandpass';
+        filter.frequency.setValueAtTime(800, now);
+        filter.Q.setValueAtTime(1.5, now);
+        noiseGain.gain.setValueAtTime(0, now);
+        noiseGain.gain.linearRampToValueAtTime(this.sfxVolume * 0.7, now + 0.005);
+        noiseGain.gain.exponentialRampToValueAtTime(0.001, now + 0.15);
+        noiseSource.start(now);
+        noiseSource.stop(now + 0.15);
+
+        // Rising confirmation tone
+        const tone = this.audioContext.createOscillator();
+        const toneGain = this.audioContext.createGain();
+        tone.connect(toneGain);
+        toneGain.connect(this.masterGain);
+        tone.type = 'square';
+        tone.frequency.setValueAtTime(200, now + 0.05);
+        tone.frequency.linearRampToValueAtTime(400, now + 0.2);
+        toneGain.gain.setValueAtTime(0, now + 0.05);
+        toneGain.gain.linearRampToValueAtTime(this.sfxVolume * 0.3, now + 0.08);
+        toneGain.gain.exponentialRampToValueAtTime(0.001, now + 0.25);
+        tone.start(now + 0.05);
+        tone.stop(now + 0.25);
+    }
+
     // Level complete victory fanfare
     playLevelComplete() {
         if (!this.isInitialized) return;

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -1389,6 +1389,14 @@ class Renderer {
                     }
                     this.ctx.fillRect(barX, barY, barWidth * healthPct, barHeight);
 
+                    // Glory Kill indicator: pulsing green glow when enemy < 25% HP (not bosses)
+                    if (healthPct <= 0.25 && !isBoss) {
+                        const gloryPulse = 0.3 + 0.4 * Math.sin(Date.now() * 0.008);
+                        this.ctx.strokeStyle = `rgba(0, 255, 136, ${gloryPulse})`;
+                        this.ctx.lineWidth = 2;
+                        this.ctx.strokeRect(barX - 2, barY - 2, barWidth + 4, barHeight + 4);
+                    }
+
                     // Elite indicator: colored diamond above health bar
                     if (entity.isElite && entity.eliteType && window.EliteVariants) {
                         const variantDef = window.EliteVariants[entity.eliteType];

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -570,6 +570,15 @@ class Player {
                 damage = Math.round(damage * this.levelBonuses.damageMultiplier);
             }
 
+            // Glory Kill: instant-kill enemies below 25% HP (not bosses)
+            const isGloryKill = closestEnemy.type !== 'boss' &&
+                closestEnemy.health > 0 &&
+                closestEnemy.health <= closestEnemy.maxHealth * 0.25;
+
+            if (isGloryKill) {
+                damage = closestEnemy.health + 1; // Guarantee kill
+            }
+
             this.lastPunchHitTime = now;
 
             if (this.stats) {
@@ -596,7 +605,8 @@ class Player {
                 if (this.stats) this.stats.enemiesKilled++;
                 const xpTable = { imp: 15, guard: 20, soldier: 30, demon: 40, berserker: 35, spitter: 25, shield_guard: 45, boss: 200 };
                 const eliteBonus = closestEnemy.isElite ? 1.5 : 1.0;
-                const xpReward = Math.round((xpTable[closestEnemy.type] || 20) * eliteBonus);
+                const xpMultiplier = isGloryKill ? 2.0 : 1.0;
+                const xpReward = Math.round((xpTable[closestEnemy.type] || 20) * eliteBonus * xpMultiplier);
                 if (this.addXP) this.addXP(xpReward);
                 this.registerKill();
 
@@ -604,25 +614,47 @@ class Player {
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (closestEnemy.type || 'enemy').charAt(0).toUpperCase() + (closestEnemy.type || 'enemy').slice(1);
                     const eliteTag = closestEnemy.isElite ? ' [ELITE]' : '';
-                    const comboText = isCombo ? 'COMBO! Punched' : 'Punched';
-                    window.game.hud.addKillFeedMessage(`${comboText} ${typeName}${eliteTag} +${xpReward} XP`, isCombo ? '#FFD700' : '#FF4444');
+                    if (isGloryKill) {
+                        window.game.hud.addKillFeedMessage(`GLORY KILL! ${typeName}${eliteTag} +${xpReward} XP`, '#00FF88');
+                    } else {
+                        const comboText = isCombo ? 'COMBO! Punched' : 'Punched';
+                        window.game.hud.addKillFeedMessage(`${comboText} ${typeName}${eliteTag} +${xpReward} XP`, isCombo ? '#FFD700' : '#FF4444');
+                    }
+                }
+
+                // Glory Kill bonus: drop a health pickup at enemy position
+                if (isGloryKill && window.game && window.game.pickupManager) {
+                    window.game.pickupManager.addPickup(closestEnemy.x, closestEnemy.y, 'health');
                 }
             }
 
             // Visual feedback
             closestEnemy.hitFlashTime = Date.now();
             if (window.game && window.game.hud) {
-                window.game.hud.emitBloodParticles(closestEnemy.x, closestEnemy.y, wasAlive && !closestEnemy.active ? 12 : 5);
-                window.game.hud.addDamageNumber(closestEnemy.x, closestEnemy.y, damage, isCombo);
-                window.game.hud.triggerScreenShake(isCombo ? 8 : 4);
+                if (isGloryKill) {
+                    // Glory Kill: green flash, large screen shake, crosshair text
+                    window.game.hud.emitBloodParticles(closestEnemy.x, closestEnemy.y, 15);
+                    window.game.hud.addDamageNumber(closestEnemy.x, closestEnemy.y, damage, true);
+                    window.game.hud.triggerScreenShake(10);
+                    window.game.hud.showCrosshairText('GLORY KILL!', '#00FF88');
+                    window.game.hud.triggerGloryKillFlash();
+                } else {
+                    window.game.hud.emitBloodParticles(closestEnemy.x, closestEnemy.y, wasAlive && !closestEnemy.active ? 12 : 5);
+                    window.game.hud.addDamageNumber(closestEnemy.x, closestEnemy.y, damage, isCombo);
+                    window.game.hud.triggerScreenShake(isCombo ? 8 : 4);
+                }
             }
 
-            // Play punch hit sound (enhanced)
-            if (window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playPunchHit) {
-                window.soundEngine.playPunchHit(isCombo);
+            // Play glory kill or punch hit sound
+            if (window.soundEngine && window.soundEngine.isInitialized) {
+                if (isGloryKill && window.soundEngine.playGloryKill) {
+                    window.soundEngine.playGloryKill();
+                } else if (window.soundEngine.playPunchHit) {
+                    window.soundEngine.playPunchHit(isCombo);
+                }
             }
 
-            console.log(`${isCombo ? 'COMBO! ' : ''}Punch hit ${closestEnemy.type} for ${damage} damage!`);
+            console.log(`${isGloryKill ? 'GLORY KILL! ' : isCombo ? 'COMBO! ' : ''}Punch hit ${closestEnemy.type} for ${damage} damage!`);
         }
     }
 

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -107,6 +107,10 @@ class HUD {
         this.crosshairTextDuration = 600; // ms
         this.crosshairTextColor = '#FFD700';
 
+        // Glory Kill flash
+        this.gloryKillFlashTime = 0;
+        this.gloryKillFlashDuration = 400; // ms
+
         // Zone vignette
         this.currentZoneTint = null;
         this.zoneTintAlpha = 0;
@@ -1159,6 +1163,24 @@ class HUD {
             this.ctx.fillRect(0, 0, w, h);
         }
 
+        // Glory Kill flash: brief green/gold edge flash
+        const timeSinceGloryKill = now - this.gloryKillFlashTime;
+        if (timeSinceGloryKill < this.gloryKillFlashDuration) {
+            const alpha = 1 - (timeSinceGloryKill / this.gloryKillFlashDuration);
+            const edgeSize = 60;
+            const r = 0, g = 255, b = 136;
+            const gradTop = this.ctx.createLinearGradient(0, 0, 0, edgeSize);
+            gradTop.addColorStop(0, `rgba(${r}, ${g}, ${b}, ${alpha * 0.6})`);
+            gradTop.addColorStop(1, `rgba(${r}, ${g}, ${b}, 0)`);
+            this.ctx.fillStyle = gradTop;
+            this.ctx.fillRect(0, 0, w, edgeSize);
+            const gradBottom = this.ctx.createLinearGradient(0, h, 0, h - edgeSize);
+            gradBottom.addColorStop(0, `rgba(${r}, ${g}, ${b}, ${alpha * 0.6})`);
+            gradBottom.addColorStop(1, `rgba(${r}, ${g}, ${b}, 0)`);
+            this.ctx.fillStyle = gradBottom;
+            this.ctx.fillRect(0, h - edgeSize, w, edgeSize);
+        }
+
         // Low-health pulse: vignette red border when health < 25%
         // Intensity scales inversely with health (lower health = stronger effect)
         if (player.health > 0 && player.health < player.maxHealth * 0.25) {
@@ -1889,6 +1911,10 @@ class HUD {
         this.crosshairText = text;
         this.crosshairTextTime = Date.now();
         this.crosshairTextColor = color || '#FFD700';
+    }
+
+    triggerGloryKillFlash() {
+        this.gloryKillFlashTime = Date.now();
     }
 
     // Called when player takes damage


### PR DESCRIPTION
## Summary
- Punching enemies below 25% HP triggers instant-kill Glory Kill with 2x XP bonus
- Health pickup drops at enemy position as reward for close-range risk
- Green screen edge flash and "GLORY KILL!" crosshair text for visual feedback
- Pulsing green glow on health bars of enemies below 25% HP signals they're finishable
- Unique heavy impact sound via procedural audio
- Bosses exempt from Glory Kill (take normal punch damage)

Fixes #290

## Test plan
- [x] All 43 tests pass
- [x] Punch attack still works normally (T2-24)
- [x] Kill feed still works (T2-28)
- [x] Damage flash still works (T2-25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)