### PR TITLE
Enhance kill feed with weapon names and slide-in animation

### DIFF
--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -615,10 +615,10 @@ class Player {
                     const typeName = (closestEnemy.type || 'enemy').charAt(0).toUpperCase() + (closestEnemy.type || 'enemy').slice(1);
                     const eliteTag = closestEnemy.isElite ? ' [ELITE]' : '';
                     if (isGloryKill) {
-                        window.game.hud.addKillFeedMessage(`GLORY KILL! ${typeName}${eliteTag} +${xpReward} XP`, '#00FF88');
+                        window.game.hud.addKillFeedMessage(`GLORY KILL! Punch → ${typeName}${eliteTag} +${xpReward}`, '#00FF88');
                     } else {
-                        const comboText = isCombo ? 'COMBO! Punched' : 'Punched';
-                        window.game.hud.addKillFeedMessage(`${comboText} ${typeName}${eliteTag} +${xpReward} XP`, isCombo ? '#FFD700' : '#FF4444');
+                        const prefix = isCombo ? 'COMBO! ' : '';
+                        window.game.hud.addKillFeedMessage(`${prefix}Punch → ${typeName}${eliteTag} +${xpReward}`, isCombo ? '#FFD700' : '#FF4444');
                     }
                 }
 

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -44,8 +44,8 @@ class HUD {
 
         // Kill feed
         this.killFeed = [];
-        this.killFeedMax = 4;
-        this.killFeedDuration = 3000; // 3 seconds
+        this.killFeedMax = 5;
+        this.killFeedDuration = 4000; // 4 seconds
 
         // Crosshair rotation (for chaingun)
         this.crosshairRotation = 0;
@@ -1832,26 +1832,36 @@ class HUD {
         const visible = this.killFeed.slice(0, this.killFeedMax);
         if (visible.length === 0) return;
 
-        const x = this.canvas.width - 160;
         const startY = 175; // Below minimap (which is 150+10 padding)
+        const slideInDuration = 200; // ms for slide-in animation
 
         for (let i = 0; i < visible.length; i++) {
             const msg = visible[i];
             const age = now - msg.time;
-            const alpha = Math.max(0, 1 - (age / this.killFeedDuration));
+            // Fade out in last second
+            const fadeStart = this.killFeedDuration - 1000;
+            const alpha = age > fadeStart ? Math.max(0, 1 - (age - fadeStart) / 1000) : 1;
             const y = startY + i * 18;
 
+            // Slide in from right
+            const slideProgress = Math.min(1, age / slideInDuration);
+            const slideOffset = (1 - slideProgress) * 100;
+
+            this.ctx.save();
+            this.ctx.globalAlpha = alpha;
+
             // Background
-            this.ctx.fillStyle = `rgba(0, 0, 0, ${alpha * 0.5})`;
-            this.ctx.fillRect(x - 5, y - 11, 170, 16);
+            const bgX = this.canvas.width - 160 - 5 + slideOffset;
+            this.ctx.fillStyle = `rgba(0, 0, 0, 0.5)`;
+            this.ctx.fillRect(bgX, y - 11, 170, 16);
 
             // Text
-            this.ctx.globalAlpha = alpha;
             this.ctx.fillStyle = msg.color;
             this.ctx.font = this.smallFont;
             this.ctx.textAlign = 'right';
-            this.ctx.fillText(msg.text, this.canvas.width - 15, y);
-            this.ctx.globalAlpha = 1.0;
+            this.ctx.fillText(msg.text, this.canvas.width - 15 + slideOffset, y);
+
+            this.ctx.restore();
         }
     }
 

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -219,13 +219,15 @@ class Weapon {
                 if (player.addXP) player.addXP(xpReward);
                 if (player.registerKill) player.registerKill();
 
-                // Kill feed message
+                // Kill feed message with weapon name
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (hit.enemy.type || 'enemy').charAt(0).toUpperCase() + (hit.enemy.type || 'enemy').slice(1);
                     const eliteTag = hit.enemy.isElite ? ' [ELITE]' : '';
-                    const prefix = isHeadshot ? 'HEADSHOT! Killed' : (isCritical ? 'CRITICAL! Killed' : 'Killed');
+                    const weaponName = (this.type || 'pistol').charAt(0).toUpperCase() + (this.type || 'pistol').slice(1);
+                    const prefix = isHeadshot ? 'HEADSHOT!' : (isCritical ? 'CRITICAL!' : '');
                     const color = isHeadshot ? '#FFD700' : (isCritical ? '#FFD700' : '#FF4444');
-                    window.game.hud.addKillFeedMessage(`${prefix} ${typeName}${eliteTag} +${xpReward} XP`, color);
+                    const msg = prefix ? `${prefix} ${weaponName} → ${typeName}${eliteTag}` : `${weaponName} → ${typeName}${eliteTag}`;
+                    window.game.hud.addKillFeedMessage(`${msg} +${xpReward}`, color);
                 }
             }
 
@@ -646,8 +648,10 @@ class Weapon {
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (hit.enemy.type || 'enemy').charAt(0).toUpperCase() + (hit.enemy.type || 'enemy').slice(1);
                     const eliteTag = hit.enemy.isElite ? ' [ELITE]' : '';
-                    const prefix = isHeadshot ? 'HEADSHOT!' : (isCritical ? 'CRITICAL!' : 'ALT!');
-                    window.game.hud.addKillFeedMessage(`${prefix} Killed ${typeName}${eliteTag} +${xpReward} XP`, isHeadshot ? '#FFD700' : '#00CCFF');
+                    const weaponName = (this.type || 'pistol').charAt(0).toUpperCase() + (this.type || 'pistol').slice(1);
+                    const prefix = isHeadshot ? 'HEADSHOT!' : (isCritical ? 'CRITICAL!' : '');
+                    const msg = prefix ? `${prefix} ${weaponName} → ${typeName}${eliteTag}` : `${weaponName} → ${typeName}${eliteTag}`;
+                    window.game.hud.addKillFeedMessage(`${msg} +${xpReward}`, isHeadshot ? '#FFD700' : '#00CCFF');
                 }
             }
 

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -1972,8 +1972,8 @@ async function T2_28_killFeed(page, result) {
     const hasRenderMethod = typeof hud.renderKillFeed === 'function';
     const hasMax = typeof hud.killFeedMax === 'number';
     const hasDuration = typeof hud.killFeedDuration === 'number';
-    const maxIs4 = hud.killFeedMax === 4;
-    const durationIs3000 = hud.killFeedDuration === 3000;
+    const maxIs4 = hud.killFeedMax === 5;
+    const durationIs3000 = hud.killFeedDuration === 4000;
 
     // Test adding messages
     let addWorks = false;
@@ -2010,8 +2010,8 @@ async function T2_28_killFeed(page, result) {
     ['killFeed array', feedData.hasKillFeed],
     ['addKillFeedMessage method', feedData.hasAddMethod],
     ['renderKillFeed method', feedData.hasRenderMethod],
-    ['max 4 messages', feedData.maxIs4],
-    ['3s fade duration', feedData.durationIs3000],
+    ['max 5 messages', feedData.maxIs4],
+    ['4s fade duration', feedData.durationIs3000],
     ['adding messages works', feedData.addWorks]
   ];
 
@@ -2022,7 +2022,7 @@ async function T2_28_killFeed(page, result) {
     result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
   } else {
     result.status = 'pass';
-    result.note = `Kill feed: max ${feedData.maxIs4 ? 4 : '?'} msgs, ${feedData.durationIs3000 ? '3s' : '?'} fade, color-coded`;
+    result.note = `Kill feed: max ${feedData.maxIs4 ? 5 : '?'} msgs, ${feedData.durationIs3000 ? '4s' : '?'} fade, color-coded`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Kill messages now show weapon name with arrow format (e.g., "Shotgun → Guard +20")
- Feed expanded from 4 to 5 visible entries, display time from 3s to 4s
- New entries slide in from right with 200ms animation
- Messages fade out over the last second (instead of linear fade from start)
- Updated punch kills to use "Punch → Enemy" format
- Updated test T2-28 for new kill feed parameters

Fixes #291

## Test plan
- [x] All 43 tests pass (T2-28 updated for new max/duration)
- [x] Kill feed still renders correctly in top-right
- [x] Weapon-specific messages from both primary and alt-fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)