### PR TITLE
Add wall bullet impact decals and blood splatter effects

### DIFF
--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -111,6 +111,11 @@ class HUD {
         this.gloryKillFlashTime = 0;
         this.gloryKillFlashDuration = 400; // ms
 
+        // Wall decals (bullet impacts, blood splatters)
+        this.wallDecals = [];
+        this.wallDecalMax = 80;
+        this.wallDecalDuration = 8000; // 8 seconds
+
         // Zone vignette
         this.currentZoneTint = null;
         this.zoneTintAlpha = 0;
@@ -210,6 +215,7 @@ class HUD {
             // Render floating damage numbers and impact effects
             this.renderDamageNumbers(player, gameEngine);
             this.renderImpactSparks(player, gameEngine);
+            this.renderWallDecals(player, gameEngine);
 
             // Render particle effects
             this.updateAndRenderParticles(player, gameEngine);
@@ -2120,7 +2126,63 @@ class HUD {
             this.ctx.fill();
         }
     }
-    
+
+    addWallDecal(worldX, worldY, type) {
+        // type: 'impact' (gray bullet mark) or 'blood' (red splatter)
+        this.wallDecals.push({
+            worldX, worldY,
+            type: type || 'impact',
+            spawnTime: Date.now(),
+            size: type === 'blood' ? 3 + Math.random() * 4 : 2 + Math.random() * 2
+        });
+        // Cap decal count
+        if (this.wallDecals.length > this.wallDecalMax) {
+            this.wallDecals.shift();
+        }
+    }
+
+    renderWallDecals(player, gameEngine) {
+        const now = Date.now();
+        this.wallDecals = this.wallDecals.filter(d => now - d.spawnTime < this.wallDecalDuration);
+
+        if (!player || !gameEngine || !gameEngine.renderer) return;
+        const renderer = gameEngine.renderer;
+
+        for (const decal of this.wallDecals) {
+            const elapsed = now - decal.spawnTime;
+            const progress = elapsed / this.wallDecalDuration;
+
+            const dx = decal.worldX - player.x;
+            const dy = decal.worldY - player.y;
+            const distance = Math.sqrt(dx * dx + dy * dy);
+            if (distance > renderer.maxRenderDistance || distance < 1) continue;
+
+            let angle = Math.atan2(dy, dx);
+            let angleDiff = angle - player.angle;
+            while (angleDiff > Math.PI) angleDiff -= Math.PI * 2;
+            while (angleDiff < -Math.PI) angleDiff += Math.PI * 2;
+            if (Math.abs(angleDiff) > renderer.fov / 2) continue;
+
+            const screenX = this.canvas.width / 2 + (angleDiff / renderer.fov) * this.canvas.width;
+            const screenY = renderer.halfHeight;
+
+            // Fade out in the last 30% of lifetime
+            const alpha = progress > 0.7 ? (1 - progress) / 0.3 : 1.0;
+            // Scale down with distance
+            const sizeFactor = Math.max(0.5, 1 - distance / renderer.maxRenderDistance);
+            const size = decal.size * sizeFactor;
+
+            if (decal.type === 'blood') {
+                this.ctx.fillStyle = `rgba(139, 0, 0, ${alpha * 0.8})`;
+            } else {
+                this.ctx.fillStyle = `rgba(60, 55, 50, ${alpha * 0.7})`;
+            }
+            this.ctx.beginPath();
+            this.ctx.arc(screenX, screenY, size, 0, Math.PI * 2);
+            this.ctx.fill();
+        }
+    }
+
     updateFogOfWar(player, map) {
         const tileX = Math.floor(player.x / map.tileSize);
         const tileY = Math.floor(player.y / map.tileSize);

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -235,6 +235,12 @@ class Weapon {
             hit.enemy.hitFlashTime = Date.now();
             if (window.game && window.game.hud) {
                 window.game.hud.emitBloodParticles(hit.enemy.x, hit.enemy.y, wasAlive && hit.enemy.dying ? 12 : 5);
+                // Blood splatter decal behind enemy (in bullet direction)
+                const bx = hit.enemy.x + Math.cos(player.angle) * 30;
+                const by = hit.enemy.y + Math.sin(player.angle) * 30;
+                if (map.isWallAtPosition(bx, by)) {
+                    window.game.hud.addWallDecal(bx, by, 'blood');
+                }
             }
 
             // Show floating damage number (gold for headshots, colored for resistance)
@@ -296,6 +302,7 @@ class Weapon {
             // Wall impact effect
             if (window.game && window.game.hud) {
                 window.game.hud.addImpactSpark(hit.hitPoint.x, hit.hitPoint.y);
+                window.game.hud.addWallDecal(hit.hitPoint.x, hit.hitPoint.y, 'impact');
             }
         }
 
@@ -685,6 +692,7 @@ class Weapon {
         if (!hit.enemy && !hit.barrel && !hit.crate && hit.hitWall) {
             if (window.game && window.game.hud) {
                 window.game.hud.addImpactSpark(hit.hitPoint.x, hit.hitPoint.y);
+                window.game.hud.addWallDecal(hit.hitPoint.x, hit.hitPoint.y, 'impact');
             }
         }
 

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -622,6 +622,7 @@ const TIER_2_TESTS = [
   { id: 'T2-32', name: 'Door animation system', fn: T2_32_doorAnimation }, // issue: #58
   { id: 'T2-33', name: 'Damage direction indicator', fn: T2_33_damageDirectionIndicator }, // issue: #59
   { id: 'T2-34', name: 'Enemy sound barks', fn: T2_34_enemySoundBarks }, // issue: #60
+  { id: 'T2-35', name: 'Wall decal system', fn: T2_35_wallDecals }, // issue: #296
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -2648,6 +2649,95 @@ async function T2_34_enemySoundBarks(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Bark system: alert/pain/attack barks, 2s cooldown, ${barkData.enemyTypes.length} enemy types`;
+  }
+}
+
+async function T2_35_wallDecals(page, result) {
+  // T2-35: Wall decal system (issue: #296)
+  // Pass condition: HUD has decal methods, decals can be created and expire
+  await page.waitForTimeout(1000);
+
+  const decalData = await page.evaluate(() => {
+    if (!window.game || !window.game.hud) {
+      return { exists: false, reason: 'HUD not found' };
+    }
+
+    const hud = window.game.hud;
+
+    // Check decal system exists
+    const hasWallDecals = Array.isArray(hud.wallDecals);
+    const hasAddWallDecal = typeof hud.addWallDecal === 'function';
+    const hasRenderWallDecals = typeof hud.renderWallDecals === 'function';
+    const hasDecalMax = typeof hud.wallDecalMax === 'number' && hud.wallDecalMax > 0;
+    const hasDecalDuration = typeof hud.wallDecalDuration === 'number' && hud.wallDecalDuration > 0;
+
+    // Test adding decals
+    const countBefore = hud.wallDecals.length;
+    hud.addWallDecal(100, 100, 'impact');
+    hud.addWallDecal(120, 120, 'blood');
+    const countAfter = hud.wallDecals.length;
+    const decalsAdded = countAfter >= countBefore + 2;
+
+    // Verify decal properties
+    const lastDecal = hud.wallDecals[hud.wallDecals.length - 1];
+    const hasWorldCoords = typeof lastDecal.worldX === 'number' && typeof lastDecal.worldY === 'number';
+    const hasType = lastDecal.type === 'blood' || lastDecal.type === 'impact';
+    const hasSpawnTime = typeof lastDecal.spawnTime === 'number';
+    const hasSize = typeof lastDecal.size === 'number' && lastDecal.size > 0;
+
+    // Test cap enforcement
+    for (let i = 0; i < hud.wallDecalMax + 10; i++) {
+      hud.addWallDecal(50 + i, 50 + i, 'impact');
+    }
+    const cappedCorrectly = hud.wallDecals.length <= hud.wallDecalMax;
+
+    // Clean up
+    hud.wallDecals = [];
+
+    return {
+      exists: true,
+      hasWallDecals,
+      hasAddWallDecal,
+      hasRenderWallDecals,
+      hasDecalMax,
+      hasDecalDuration,
+      decalsAdded,
+      hasWorldCoords,
+      hasType,
+      hasSpawnTime,
+      hasSize,
+      cappedCorrectly
+    };
+  });
+
+  if (!decalData.exists) {
+    result.status = 'fail';
+    result.note = decalData.reason;
+    return;
+  }
+
+  const checks = [
+    ['wallDecals array', decalData.hasWallDecals],
+    ['addWallDecal method', decalData.hasAddWallDecal],
+    ['renderWallDecals method', decalData.hasRenderWallDecals],
+    ['decal max cap', decalData.hasDecalMax],
+    ['decal duration', decalData.hasDecalDuration],
+    ['decals added correctly', decalData.decalsAdded],
+    ['world coordinates', decalData.hasWorldCoords],
+    ['decal type', decalData.hasType],
+    ['spawn time', decalData.hasSpawnTime],
+    ['decal size', decalData.hasSize],
+    ['cap enforced', decalData.cappedCorrectly]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Wall decals: impact + blood types, max ${decalData.hasDecalMax ? 'capped' : 'uncapped'}, timed expiry`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds persistent wall decal system with bullet impact marks (gray) and blood splatters (dark red)
- Decals spawn on wall hits and behind enemies near walls during combat
- Decals fade out over 8 seconds, capped at 80 max for performance

## Test plan
- [x] T2-35 test verifies decal creation, properties, cap enforcement, and render method
- [x] All existing tests pass (43/43 + 3 skipped vision tests)

Fixes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)