### PR TITLE
Add enhanced death screen run statistics

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -719,7 +719,8 @@ class GameEngine {
                 bestStreak: bestStreak,
                 damageDealt: Math.round(stats.damageDealt),
                 survivalTime: Math.floor(elapsed),
-                level: this.player.level
+                level: this.player.level,
+                floor: this.currentLevel || 1
             };
 
             // Check for new records
@@ -794,7 +795,7 @@ class GameEngine {
         const panelX = w * 0.2;
         const panelY = h * 0.15;
         const panelW = w * 0.6;
-        const panelH = h * 0.58;
+        const panelH = h * 0.65;
         ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
         ctx.fillRect(panelX, panelY, panelW, panelH);
         ctx.strokeStyle = '#FF4444';
@@ -806,15 +807,21 @@ class GameEngine {
         let y = panelY + 32;
         const lineH = 28;
 
+        const floorReached = this.currentLevel || 1;
+        const mapName = this.map && this.map.themeName ? this.map.themeName : 'Unknown';
+        const critHits = stats.criticalHits || 0;
+
         const statLines = [
             ['Survival Time', timeStr, 'survivalTime'],
+            ['Floor Reached', `${floorReached} — ${mapName}`, 'floor'],
             ['Enemies Killed', `${stats.enemiesKilled}`, 'kills'],
             ['Accuracy', `${accuracy}%`, 'accuracy'],
             ['Headshots', `${headshots} (${headshotPct}%)`, 'headshots'],
+            ['Critical Hits', `${critHits}`, null],
             ['Damage Dealt', `${Math.round(stats.damageDealt)}`, 'damageDealt'],
             ['Damage Taken', `${Math.round(stats.damageTaken)}`, null],
             ['Best Combo', `${bestStreak}x`, 'bestStreak'],
-            ['Level Reached', `${this.player.level}`, 'level'],
+            ['Player Level', `${this.player.level}`, 'level'],
             ['Secrets Found', `${this.map.secretsFound}/${this.map.totalSecrets}`, null]
         ];
 

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -623,6 +623,7 @@ const TIER_2_TESTS = [
   { id: 'T2-33', name: 'Damage direction indicator', fn: T2_33_damageDirectionIndicator }, // issue: #59
   { id: 'T2-34', name: 'Enemy sound barks', fn: T2_34_enemySoundBarks }, // issue: #60
   { id: 'T2-35', name: 'Wall decal system', fn: T2_35_wallDecals }, // issue: #296
+  { id: 'T2-36', name: 'Death screen run statistics', fn: T2_36_deathScreenStats }, // issue: #297
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -2738,6 +2739,75 @@ async function T2_35_wallDecals(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Wall decals: impact + blood types, max ${decalData.hasDecalMax ? 'capped' : 'uncapped'}, timed expiry`;
+  }
+}
+
+async function T2_36_deathScreenStats(page, result) {
+  // T2-36: Death screen run statistics (issue: #297)
+  // Pass condition: Death screen shows floor reached, critical hits, and map name
+  await page.waitForTimeout(1000);
+
+  const statsData = await page.evaluate(() => {
+    if (!window.game) {
+      return { exists: false, reason: 'Game not found' };
+    }
+
+    const game = window.game;
+
+    // Check renderDeathScreen method exists
+    const hasRenderDeathScreen = typeof game.renderDeathScreen === 'function';
+
+    // Check that renderDeathScreen source includes floor and critical hit stats
+    const src = game.renderDeathScreen.toString();
+    const hasFloorReached = src.includes('Floor Reached') || src.includes('floorReached');
+    const hasCriticalHits = src.includes('Critical Hits') || src.includes('critHits');
+    const hasMapName = src.includes('themeName') || src.includes('mapName');
+    const hasPlayerLevel = src.includes('Player Level') || src.includes('player.level');
+
+    // Check saveBestRun tracks floor
+    const hasSaveBestRun = typeof game.saveBestRun === 'function';
+    const saveSrc = hasSaveBestRun ? game.saveBestRun.toString() : '';
+    const bestRunTracksFloor = saveSrc.includes('floor');
+
+    // Check currentLevel property exists
+    const hasCurrentLevel = typeof game.currentLevel === 'number';
+
+    return {
+      exists: true,
+      hasRenderDeathScreen,
+      hasFloorReached,
+      hasCriticalHits,
+      hasMapName,
+      hasPlayerLevel,
+      bestRunTracksFloor,
+      hasCurrentLevel
+    };
+  });
+
+  if (!statsData.exists) {
+    result.status = 'fail';
+    result.note = statsData.reason;
+    return;
+  }
+
+  const checks = [
+    ['renderDeathScreen method', statsData.hasRenderDeathScreen],
+    ['Floor Reached stat', statsData.hasFloorReached],
+    ['Critical Hits stat', statsData.hasCriticalHits],
+    ['Map name display', statsData.hasMapName],
+    ['Player Level stat', statsData.hasPlayerLevel],
+    ['Best run tracks floor', statsData.bestRunTracksFloor],
+    ['currentLevel property', statsData.hasCurrentLevel]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = 'Death screen: floor reached, critical hits, map name, best run tracking';
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds floor reached with map theme name to death screen stats
- Adds critical hits counter to death screen
- Tracks floor in best run localStorage records
- Expanded stats panel for additional stat lines

## Test plan
- [x] T2-36 test verifies death screen has floor, critical hits, map name, and best run tracking
- [x] All 45 tests pass (+ 3 skipped vision tests)

Fixes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)