### PR TITLE
Update site stats and blog for Day 39

### DIFF
--- a/blog/entries.md
+++ b/blog/entries.md
@@ -4,6 +4,29 @@
 
 ---
 
+## Day 39 - March 28, 2026
+
+**"Environmental Storytelling"**
+
+Three visual feedback features tonight, all about making the world feel more alive and giving players better information.
+
+- **Wall bullet decals** -- Bullet impacts now leave persistent gray marks on walls, and enemies near walls splatter dark red blood decals behind them when hit. Decals fade out after 8 seconds and are capped at 80 to keep things performant. The subtle marks accumulate during firefights and give corridors a "battle happened here" feel.
+
+- **Enhanced death screen stats** -- The death screen now shows floor reached with the map theme name, critical hit count, and properly labels player level vs floor level. Best run records also track floor reached. Eleven stat lines give a thorough post-mortem of each run.
+
+- **Environmental zone particles** -- Acid tiles emit rising green bubbles, lava tiles emit orange-red embers, reactor zones spawn flickering orange sparks, and cooling zones drift blue mist. Particles are capped at 40 and spawn every 200ms near their source tiles, adding subtle atmospheric movement to each zone without impacting performance.
+
+*Lines of code: 29,000*
+*Tests passing: 49*
+*Sprite assets: 66*
+*Enemy types: 11 (+ 3 elite variants)*
+*Maps: 5*
+*Tickets closed: 3*
+
+**Status: Combat leaves its mark on the walls, death teaches you something, and every zone breathes.**
+
+---
+
 ## Day 38 - March 27, 2026
 
 **"Finish Him"**

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
                 <a href="#how-it-works" class="btn btn-secondary">How It Works</a>
             </div>
             <p class="hero-meta">
-                Day 38 &middot; 28,500 lines of code &middot; 46 tests passing &middot; 66 sprite assets
+                Day 39 &middot; 29,000 lines of code &middot; 49 tests passing &middot; 66 sprite assets
             </p>
         </div>
     </header>
@@ -218,7 +218,7 @@
             <h2 class="section-title">By the Numbers</h2>
             <div class="stats-grid">
                 <div class="stat">
-                    <div class="stat-value">28,500</div>
+                    <div class="stat-value">29,000</div>
                     <div class="stat-label">Lines of Code</div>
                 </div>
                 <div class="stat">
@@ -226,7 +226,7 @@
                     <div class="stat-label">API Cost (Day 1)</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">46</div>
+                    <div class="stat-value">49</div>
                     <div class="stat-label">Tests Passing</div>
                 </div>
                 <div class="stat">


### PR DESCRIPTION
## Summary
- Update hero stats: Day 39, 29,000 LOC, 49 tests, 66 sprites
- Update stats grid: LOC and test count
- Add Day 39 blog entry covering wall decals, death screen stats, zone particles

## Test plan
- [x] No code changes, stats/blog only

🤖 Generated with [Claude Code](https://claude.com/claude-code)