### PR TITLE
Add enemy alert propagation system

### DIFF
--- a/js/audio/sound-engine.js
+++ b/js/audio/sound-engine.js
@@ -2001,6 +2001,43 @@ class SoundEngine {
             this.masterGain.gain.setValueAtTime(volume, this.audioContext.currentTime);
         }
     }
+    // Alert bark — louder, two-tone call when an enemy alerts nearby allies
+    playAlertBark(enemyType = 'guard') {
+        if (!this.isInitialized) return;
+        const now = this.audioContext.currentTime;
+
+        const params = {
+            guard:       { freq: 280, type: 'sawtooth' },
+            imp:         { freq: 450, type: 'square' },
+            demon:       { freq: 100, type: 'sawtooth' },
+            soldier:     { freq: 300, type: 'square' },
+            berserker:   { freq: 160, type: 'sawtooth' },
+            spitter:     { freq: 380, type: 'triangle' },
+            shield_guard:{ freq: 240, type: 'square' },
+            boss:        { freq: 70,  type: 'sawtooth' },
+            phantom:     { freq: 500, type: 'sine' },
+            exploder:    { freq: 340, type: 'square' },
+            sniper:      { freq: 320, type: 'triangle' },
+        };
+        const p = params[enemyType] || params.guard;
+
+        // Two quick rising tones (alarm call)
+        for (let i = 0; i < 2; i++) {
+            const t = now + i * 0.12;
+            const osc = this.audioContext.createOscillator();
+            const gain = this.audioContext.createGain();
+            osc.connect(gain);
+            gain.connect(this.masterGain);
+            osc.type = p.type;
+            osc.frequency.setValueAtTime(p.freq * (1 + i * 0.3), t);
+            osc.frequency.linearRampToValueAtTime(p.freq * (1.5 + i * 0.3), t + 0.08);
+            gain.gain.setValueAtTime(0, t);
+            gain.gain.linearRampToValueAtTime(this.sfxVolume * 0.3, t + 0.01);
+            gain.gain.exponentialRampToValueAtTime(0.001, t + 0.1);
+            osc.start(t);
+            osc.stop(t + 0.1);
+        }
+    }
 }
 
 // Global sound engine instance

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -1423,6 +1423,26 @@ class Renderer {
                     this.ctx.globalAlpha = 1.0;
                 }
             }
+
+            // Alert indicator: "!" above enemy when freshly alerted by another enemy
+            if (!entity.dying && entity.alertIndicatorTime) {
+                const alertAge = Date.now() - entity.alertIndicatorTime;
+                if (alertAge < 1500) {
+                    const alertAlpha = alertAge < 200 ? alertAge / 200 : Math.max(0, 1 - (alertAge - 800) / 700);
+                    const bounceY = alertAge < 300 ? -8 * (1 - alertAge / 300) : 0;
+                    this.ctx.globalAlpha = alertAlpha;
+                    const alertSize = Math.max(12, spriteSize * 0.15);
+                    this.ctx.font = `bold ${alertSize}px monospace`;
+                    this.ctx.textAlign = 'center';
+                    this.ctx.fillStyle = '#FFD700';
+                    this.ctx.strokeStyle = '#000000';
+                    this.ctx.lineWidth = 2;
+                    const alertY = spriteY - 8 + bounceY;
+                    this.ctx.strokeText('!', screenX, alertY);
+                    this.ctx.fillText('!', screenX, alertY);
+                    this.ctx.globalAlpha = 1.0;
+                }
+            }
         } else if (entityType === 'pickup') {
             const size = (this.wallHeight * this.projectionDistance) / distance * 0.3;
             const wallScreenHeight = (this.wallHeight * this.projectionDistance) / distance;

--- a/js/entities/enemy-behaviors.js
+++ b/js/entities/enemy-behaviors.js
@@ -819,10 +819,53 @@ class EnhancedEnemyAI {
     }
     
     callForHelpIfNeeded(player) {
-        if (this.behavior.callForHelp && !this.helpCalled) {
+        if (!this.helpCalled) {
             this.helpCalled = true;
-            // Alert nearby enemies (would be handled by enemy manager)
-            console.log('Enemy calls for help!');
+            // Propagate alert to nearby enemies
+            this.alertNearbyEnemies(player);
+        }
+    }
+
+    alertNearbyEnemies(player) {
+        const now = Date.now();
+        // Cooldown: don't spam alerts (3 seconds)
+        if (now - this.enemy.lastAlertPropagation < 3000) return;
+        this.enemy.lastAlertPropagation = now;
+
+        if (!window.game || !window.game.map) return;
+        const allEnemies = window.game.map.enemies;
+        const alertRadius = 5 * (window.game.map.tileSize || 64); // 5 tiles
+
+        for (const other of allEnemies) {
+            if (other === this.enemy) continue;
+            if (!other.active || other.dying) continue;
+            // Only alert idle/patrol enemies (already engaged enemies don't need alerting)
+            if (other.state !== 'idle' && other.state !== 'patrol') continue;
+
+            const dx = other.x - this.enemy.x;
+            const dy = other.y - this.enemy.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+
+            if (dist < alertRadius) {
+                // Alert the other enemy
+                other.alertedTime = now;
+                other.alertIndicatorTime = now;
+                other.lastPlayerX = player.x;
+                other.lastPlayerY = player.y;
+                other.state = 'chase';
+                other.hasPlayedAlert = true;
+
+                // If other enemy has enhanced AI, update its state too
+                if (other.enhancedAI) {
+                    other.enhancedAI.alertLevel = Math.max(other.enhancedAI.alertLevel, 0.7);
+                    other.enhancedAI.lastKnownPlayerPos = { x: player.x, y: player.y };
+                }
+            }
+        }
+
+        // Play alert bark sound
+        if (window.soundEngine && window.soundEngine.isInitialized) {
+            window.soundEngine.playAlertBark(this.enemy.type);
         }
     }
     

--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -39,6 +39,11 @@ class Enemy {
         this.painCooldown = 500; // 0.5s between pain sounds
         this.hasPlayedAlert = false;
 
+        // Alert propagation
+        this.alertedTime = 0; // When this enemy was alerted by another
+        this.alertIndicatorTime = 0; // When to show "!" indicator
+        this.lastAlertPropagation = 0; // Cooldown for outgoing alerts
+
         // Knockback velocity (from explosions)
         this.knockbackVX = 0;
         this.knockbackVY = 0;
@@ -150,13 +155,14 @@ class Enemy {
                     if (!this.hasPlayedAlert) {
                         this.hasPlayedAlert = true;
                         this.tryBark('alert');
+                        this.alertNearby(player);
                     }
                     console.log('Enemy detected player!');
                 } else if (now - this.lastMoveTime > this.moveInterval) {
                     this.state = 'patrol';
                 }
                 break;
-                
+
             case 'patrol':
                 this.patrol(deltaTime, map);
                 if (playerDistance < this.detectionRange) {
@@ -164,6 +170,7 @@ class Enemy {
                     if (!this.hasPlayedAlert) {
                         this.hasPlayedAlert = true;
                         this.tryBark('alert');
+                        this.alertNearby(player);
                     }
                 }
                 break;
@@ -536,6 +543,42 @@ class Enemy {
             case 'attack':
                 window.soundEngine.playEnemyAttackBark(this.type);
                 break;
+        }
+    }
+
+    // Alert nearby enemies when this enemy detects the player (fallback AI path)
+    alertNearby(player) {
+        const now = Date.now();
+        if (now - this.lastAlertPropagation < 3000) return;
+        this.lastAlertPropagation = now;
+
+        if (!window.game || !window.game.map) return;
+        const allEnemies = window.game.map.enemies;
+        const tileSize = window.game.map.tileSize || 64;
+        const alertRadius = 5 * tileSize;
+
+        for (const other of allEnemies) {
+            if (other === this || !other.active || other.dying) continue;
+            if (other.state !== 'idle' && other.state !== 'patrol') continue;
+
+            const dx = other.x - this.x;
+            const dy = other.y - this.y;
+            if (Math.sqrt(dx * dx + dy * dy) < alertRadius) {
+                other.alertedTime = now;
+                other.alertIndicatorTime = now;
+                other.lastPlayerX = player.x;
+                other.lastPlayerY = player.y;
+                other.state = 'chase';
+                other.hasPlayedAlert = true;
+                if (other.enhancedAI) {
+                    other.enhancedAI.alertLevel = Math.max(other.enhancedAI.alertLevel, 0.7);
+                    other.enhancedAI.lastKnownPlayerPos = { x: player.x, y: player.y };
+                }
+            }
+        }
+
+        if (window.soundEngine && window.soundEngine.isInitialized) {
+            window.soundEngine.playAlertBark(this.type);
         }
     }
 

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -2517,7 +2517,9 @@ class HUD {
             if (!this.isTileVisible(egx, egy)) continue;
             const rx = (enemy.x - player.x) * scale;
             const ry = (enemy.y - player.y) * scale;
-            this.ctx.fillStyle = enemy.type === 'boss' ? '#FFD700' : '#FF4444';
+            // Yellow for recently alerted enemies, gold for boss, red for actively engaged
+            const isRecentlyAlerted = enemy.alertedTime && (Date.now() - enemy.alertedTime < 3000);
+            this.ctx.fillStyle = enemy.type === 'boss' ? '#FFD700' : (isRecentlyAlerted ? '#FFCC00' : '#FF4444');
             const dotScale = enemyScales[enemy.type] || 0.6;
             const dotRadius = Math.max(cellSize * 0.4 * (dotScale / 0.6), 2.5);
             this.ctx.beginPath();

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -625,6 +625,7 @@ const TIER_2_TESTS = [
   { id: 'T2-35', name: 'Wall decal system', fn: T2_35_wallDecals }, // issue: #296
   { id: 'T2-36', name: 'Death screen run statistics', fn: T2_36_deathScreenStats }, // issue: #297
   { id: 'T2-37', name: 'Environmental zone particles', fn: T2_37_zoneParticles }, // issue: #298
+  { id: 'T2-38', name: 'Enemy alert propagation', fn: T2_38_enemyAlertPropagation }, // issue: #304
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -2900,6 +2901,100 @@ async function T2_37_zoneParticles(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Zone particles: acid, lava, reactor sparks, cooling mist (max ${particleData.hasMaxCap ? 'capped' : 'uncapped'})`;
+  }
+}
+
+async function T2_38_enemyAlertPropagation(page, result) {
+  // T2-38: Enemy alert propagation system (issue: #304)
+  // Pass condition: Enemies have alert properties, alertNearby method, SoundEngine has playAlertBark
+  await page.waitForTimeout(1000);
+
+  const alertData = await page.evaluate(() => {
+    if (!window.game || !window.game.map) {
+      return { exists: false, reason: 'Game not loaded' };
+    }
+
+    const enemies = window.game.map.enemies || [];
+    if (enemies.length === 0) {
+      return { exists: false, reason: 'No enemies found' };
+    }
+
+    const enemy = enemies[0];
+
+    // Check alert propagation properties on enemy
+    const hasAlertedTime = typeof enemy.alertedTime === 'number';
+    const hasAlertIndicatorTime = typeof enemy.alertIndicatorTime === 'number';
+    const hasLastAlertPropagation = typeof enemy.lastAlertPropagation === 'number';
+
+    // Check alertNearby method exists (original AI path)
+    const hasAlertNearby = typeof enemy.alertNearby === 'function';
+
+    // Check SoundEngine has playAlertBark method
+    const se = window.soundEngine;
+    const hasAlertBarkMethod = typeof se.playAlertBark === 'function';
+
+    // Verify alert propagation works: create two test enemies close together
+    let propagationWorks = false;
+    if (enemies.length >= 2) {
+      const src = enemies[0];
+      const target = enemies[1];
+      // Save original states
+      const origState = target.state;
+      const origAlertTime = target.alertedTime;
+      // Place them close together
+      const origX = target.x;
+      const origY = target.y;
+      target.x = src.x + 32;
+      target.y = src.y + 32;
+      target.state = 'idle';
+      target.alertedTime = 0;
+      // Trigger alert
+      src.lastAlertPropagation = 0; // Reset cooldown
+      if (hasAlertNearby) {
+        src.alertNearby(window.game.player);
+        propagationWorks = target.alertedTime > 0 && target.state === 'chase';
+      }
+      // Restore
+      target.x = origX;
+      target.y = origY;
+      target.state = origState;
+      target.alertedTime = origAlertTime;
+    }
+
+    return {
+      exists: true,
+      hasAlertedTime,
+      hasAlertIndicatorTime,
+      hasLastAlertPropagation,
+      hasAlertNearby,
+      hasAlertBarkMethod,
+      propagationWorks
+    };
+  });
+
+  if (!alertData.exists) {
+    result.status = 'fail';
+    result.note = alertData.reason;
+    return;
+  }
+
+  const checks = [
+    ['alertedTime property', alertData.hasAlertedTime],
+    ['alertIndicatorTime property', alertData.hasAlertIndicatorTime],
+    ['lastAlertPropagation property', alertData.hasLastAlertPropagation],
+    ['alertNearby method', alertData.hasAlertNearby],
+    ['playAlertBark sound', alertData.hasAlertBarkMethod],
+    ['alert propagation works', alertData.propagationWorks]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = 'Enemy alert propagation: properties, alertNearby(), playAlertBark(), propagation verified';
   }
 }
 


### PR DESCRIPTION
## Summary
- Enemies now alert nearby allies (within 5 tiles) when they detect the player
- Alerted enemies enter chase state and get a "!" indicator above their head
- Yellow minimap blips distinguish alerted enemies from actively engaged ones
- Two-tone alert bark sound provides audio feedback
- Works in both original and enhanced AI paths
- 3-second cooldown prevents alert spam

## Test plan
- [x] T2-38 test verifies alert properties, alertNearby() method, playAlertBark() sound, and propagation behavior
- [x] All existing tests pass (T2-03 is known flaky)

Fixes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)