### PR TITLE
Add enemy morale and retreat behavior

### DIFF
--- a/js/entities/enemy-behaviors.js
+++ b/js/entities/enemy-behaviors.js
@@ -256,7 +256,12 @@ class EnhancedEnemyAI {
         this.coverPosition = null;
         this.strafeDirection = Math.random() > 0.5 ? 1 : -1;
         this.fleeTarget = null;
-        
+
+        // Morale system
+        this.morale = 1.0; // 1.0 = full courage, 0.0 = broken
+        this.moraleRecoveryRate = 0.05; // per second recovery when not stressed
+        this.moraleFleeThreshold = 0.3; // flee when morale drops below this
+
         // Group coordination
         this.groupId = null;
         this.isGroupLeader = false;
@@ -267,6 +272,9 @@ class EnhancedEnemyAI {
     update(deltaTime, player, map, allEnemies) {
         // Update alert level
         this.updateAlertLevel(player);
+
+        // Update morale (recover slowly over time)
+        this.updateMorale(deltaTime, player);
 
         // Clear dead infight targets
         if (this.enemy.infightTarget && (!this.enemy.infightTarget.active || this.enemy.infightTarget.dying)) {
@@ -362,9 +370,9 @@ class EnhancedEnemyAI {
     chaseBehavior(player, deltaTime, map, allEnemies) {
         const distance = this.getDistanceToPlayer(player);
 
-        // Check if should flee
+        // Check if should flee (health OR morale)
         const healthPercent = this.enemy.health / this.enemy.maxHealth;
-        if (healthPercent < this.behavior.fleeHealthThreshold) {
+        if (healthPercent < this.behavior.fleeHealthThreshold || this.morale < this.moraleFleeThreshold) {
             this.enemy.state = 'flee';
             return;
         }
@@ -416,6 +424,12 @@ class EnhancedEnemyAI {
         const distance = this.getDistanceToPlayer(player);
         const now = Date.now();
 
+        // Check morale - flee if broken
+        if (this.morale < this.moraleFleeThreshold) {
+            this.enemy.state = 'flee';
+            return;
+        }
+
         // Berserker rage - boost speed and damage at low health
         if (this.behavior.berserkerRage) {
             const healthPercent = this.enemy.health / this.enemy.maxHealth;
@@ -461,20 +475,25 @@ class EnhancedEnemyAI {
     }
     
     fleeBehavior(player, deltaTime, map) {
+        // Morale recovers faster while fleeing (relief from disengagement)
+        this.morale += 0.1 * deltaTime;
+        this.morale = Math.min(1, this.morale);
+
         // Find safe retreat position
         if (!this.fleeTarget) {
             this.findFleeTarget(player, map);
         }
-        
+
         this.enemy.targetX = this.fleeTarget.x;
         this.enemy.targetY = this.fleeTarget.y;
-        
-        // Check if reached safety or health improved
-        const distance = Math.sqrt((this.enemy.x - this.fleeTarget.x) ** 2 + 
+
+        // Check if reached safety, health improved, or morale rallied
+        const distance = Math.sqrt((this.enemy.x - this.fleeTarget.x) ** 2 +
                                  (this.enemy.y - this.fleeTarget.y) ** 2);
-        
+
         const healthPercent = this.enemy.health / this.enemy.maxHealth;
-        if (distance < 20 || healthPercent > this.behavior.fleeHealthThreshold + 0.1) {
+        const rallied = this.morale > this.moraleFleeThreshold + 0.2;
+        if (distance < 20 || healthPercent > this.behavior.fleeHealthThreshold + 0.1 || rallied) {
             this.enemy.state = 'patrol';
             this.fleeTarget = null;
         }
@@ -1183,6 +1202,46 @@ class EnhancedEnemyAI {
         this.enemy.bossSpecialTelegraph = null;
     }
 
+    updateMorale(deltaTime, player) {
+        const type = this.enemy.type;
+        // Bosses and berserkers are immune to morale loss
+        if (type === 'boss' || type === 'berserker') {
+            this.morale = 1.0;
+            return;
+        }
+
+        // Player combo pressure: reduce morale when player is on a kill streak
+        if (player.comboCount && player.comboCount >= 3) {
+            this.morale -= 0.02 * deltaTime;
+        }
+
+        // Low health amplifies morale loss
+        const healthPct = this.enemy.health / this.enemy.maxHealth;
+        if (healthPct < 0.4) {
+            this.morale -= 0.03 * deltaTime;
+        }
+
+        // Slowly recover morale when not under immediate stress
+        if (healthPct > 0.5 && (!player.comboCount || player.comboCount < 2)) {
+            this.morale += this.moraleRecoveryRate * deltaTime;
+        }
+
+        this.morale = Math.max(0, Math.min(1, this.morale));
+    }
+
+    onNearbyAllyDeath() {
+        const type = this.enemy.type;
+        // Bosses and berserkers are immune
+        if (type === 'boss' || type === 'berserker') return;
+        // Enraged elites get a morale boost instead
+        if (this.enemy.isElite && this.enemy.eliteType === 'enraged') {
+            this.morale = Math.min(1, this.morale + 0.15);
+            return;
+        }
+        this.morale -= 0.2;
+        this.morale = Math.max(0, this.morale);
+    }
+
     findFleeTarget(player, map) {
         // Find position away from player
         const fleeAngle = Math.atan2(this.enemy.y - player.y, this.enemy.x - player.x);
@@ -1267,9 +1326,10 @@ function applyEliteVariant(enemy, variantType) {
         enemy.regenRate = variant.regenRate;
     }
 
-    // Enraged: never flee
-    if (variantType === 'enraged' && enemy.enhancedAI && enemy.enhancedAI.behavior) {
-        enemy.enhancedAI.behavior.fleeHealthThreshold = 0;
+    // Enraged: never flee (neither from health nor morale)
+    if (variantType === 'enraged' && enemy.enhancedAI) {
+        if (enemy.enhancedAI.behavior) enemy.enhancedAI.behavior.fleeHealthThreshold = 0;
+        enemy.enhancedAI.moraleFleeThreshold = 0;
     }
 }
 

--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -481,6 +481,21 @@ class Enemy {
                 window.game.hud.emitBloodParticles(this.x, this.y, 15);
             }
 
+            // Morale impact: nearby enemies lose morale when ally dies
+            if (window.game && window.game.map) {
+                const deathX = this.x;
+                const deathY = this.y;
+                const moraleRadius = 300;
+                for (const other of window.game.map.enemies) {
+                    if (other === this || !other.active || other.dying) continue;
+                    const dx = other.x - deathX;
+                    const dy = other.y - deathY;
+                    if (Math.sqrt(dx * dx + dy * dy) < moraleRadius && other.enhancedAI) {
+                        other.enhancedAI.onNearbyAllyDeath();
+                    }
+                }
+            }
+
             // Loot drops based on enemy type (ammo via spawnAmmoCrate + health/armor)
             if (window.game && window.game.pickupManager) {
                 this.dropLoot();

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -629,6 +629,7 @@ const TIER_2_TESTS = [
   { id: 'T2-39', name: 'Quick-switch weapon (Q key)', fn: T2_39_quickSwitchWeapon }, // issue: #309
   { id: 'T2-40', name: 'Environmental sound effects', fn: T2_40_environmentalSounds }, // issue: #307
   { id: 'T2-41', name: 'CRT scanline and vignette effects', fn: T2_41_crtEffects }, // issue: #314
+  { id: 'T2-42', name: 'Enemy morale and retreat behavior', fn: T2_42_enemyMorale }, // issue: #315
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -3204,6 +3205,86 @@ async function T2_41_crtEffects(page, result) {
   } else {
     result.status = 'pass';
     result.note = 'CRT effects: scanlines + vignette, toggleable on/off';
+  }
+}
+
+// T2-42: Enemy morale and retreat behavior (issue #315)
+async function T2_42_enemyMorale(page, result) {
+  const moraleData = await page.evaluate(() => {
+    if (!window.game || !window.game.map) return { exists: false, reason: 'No game/map' };
+
+    const enemies = window.game.map.enemies.filter(e => e.active && !e.dying && e.enhancedAI);
+    if (enemies.length === 0) return { exists: false, reason: 'No enhanced AI enemies' };
+
+    const enemy = enemies.find(e => e.type !== 'boss' && e.type !== 'berserker') || enemies[0];
+    const ai = enemy.enhancedAI;
+
+    const hasMorale = typeof ai.morale === 'number';
+    const hasUpdateMorale = typeof ai.updateMorale === 'function';
+    const hasOnAllyDeath = typeof ai.onNearbyAllyDeath === 'function';
+    const hasFleeThreshold = typeof ai.moraleFleeThreshold === 'number';
+    const hasRecoveryRate = typeof ai.moraleRecoveryRate === 'number';
+
+    // Test morale decrease on ally death
+    const before = ai.morale;
+    ai.onNearbyAllyDeath();
+    const after = ai.morale;
+    const decreased = after < before;
+    ai.morale = before; // restore
+
+    // Boss immunity check
+    const bosses = enemies.filter(e => e.type === 'boss');
+    let bossImmune = true;
+    if (bosses.length > 0 && bosses[0].enhancedAI) {
+      const bAi = bosses[0].enhancedAI;
+      const bBefore = bAi.morale;
+      bAi.onNearbyAllyDeath();
+      bossImmune = bAi.morale === bBefore;
+      bAi.morale = bBefore;
+    }
+
+    // Check flee integration: chaseBehavior references morale
+    const chaseStr = ai.chaseBehavior ? ai.chaseBehavior.toString() : '';
+    const fleeCheckInChase = chaseStr.includes('morale') || chaseStr.includes('moraleFleeThreshold');
+
+    return {
+      exists: true,
+      hasMorale,
+      hasUpdateMorale,
+      hasOnAllyDeath,
+      hasFleeThreshold,
+      hasRecoveryRate,
+      decreased,
+      bossImmune,
+      fleeCheckInChase,
+      initialMorale: before
+    };
+  });
+
+  if (!moraleData.exists) {
+    result.status = 'fail';
+    result.note = moraleData.reason;
+    return;
+  }
+
+  const checks = [
+    ['morale property', moraleData.hasMorale],
+    ['updateMorale method', moraleData.hasUpdateMorale],
+    ['onNearbyAllyDeath method', moraleData.hasOnAllyDeath],
+    ['moraleFleeThreshold', moraleData.hasFleeThreshold],
+    ['morale decreased on ally death', moraleData.decreased],
+    ['boss immune to morale loss', moraleData.bossImmune],
+    ['flee check in chase behavior', moraleData.fleeCheckInChase]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Morale system: ally death impact, boss immunity, flee integration`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Enemies now have a morale system that affects their willingness to fight
- Morale drops when nearby allies die, when player is on a kill combo, or when health is low
- Low-morale enemies flee; morale recovers over time allowing them to rally back
- Bosses/berserkers are immune; enraged elites gain morale when allies fall
- Fixes #315

## Test plan
- [x] T2-42 verifies morale properties, updateMorale/onNearbyAllyDeath methods, boss immunity, flee integration
- [x] All existing tests pass (T2-03 flaky as known)

🤖 Generated with [Claude Code](https://claude.com/claude-code)