### PR TITLE
Add level-up perk selection system

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -95,6 +95,9 @@ class GameEngine {
         // Weapon mod selection screen (shown after intermission)
         this.modSelection = { active: false, choices: [], hoveredIndex: -1 };
 
+        // Perk selection screen (shown on level-up)
+        this.perkSelection = { active: false, choices: [], hoveredIndex: -1 };
+
         // Initialize systems
         this.initialize();
     }
@@ -282,6 +285,7 @@ class GameEngine {
         this.momentum = 1.0;
         this.currentLevel = 1;
         this.modSelection = { active: false, choices: [], hoveredIndex: -1 };
+        this.perkSelection = { active: false, choices: [], hoveredIndex: -1 };
 
         // Reshuffle map rotation and pick first theme
         this.shuffleMapQueue();
@@ -391,7 +395,13 @@ class GameEngine {
     
     update(deltaTime) {
         // Skip updates while player is dead or level is complete
-        if (this.player.isDead || this.levelComplete || this.showDeathScreen || this.intermission.active || this.modSelection.active) return;
+        if (this.player.isDead || this.levelComplete || this.showDeathScreen || this.intermission.active || this.modSelection.active || this.perkSelection.active) return;
+
+        // Check for pending perk selection (triggered by level-up)
+        if (this.player.pendingPerkSelection) {
+            this.showPerkSelection();
+            return;
+        }
 
         // Update game systems
         this.player.update(deltaTime, this.map);
@@ -990,12 +1000,14 @@ class GameEngine {
         this.levelComplete = false;
         this.showDeathScreen = false;
 
-        // Keep player progress (health, armor, weapons, XP, level)
+        // Keep player progress (health, armor, weapons, XP, level, perks)
         const savedHealth = this.player.health;
         const savedArmor = this.player.armor;
         const savedLevel = this.player.level;
         const savedXP = this.player.xp;
         const savedWeaponManager = this.player.weaponManager;
+        const savedPerks = this.player.perks.slice();
+        const savedLevelBonuses = Object.assign({}, this.player.levelBonuses);
 
         // Advance to next map in rotation
         this.currentTheme = this.advanceMapQueue();
@@ -1015,6 +1027,10 @@ class GameEngine {
         this.player.level = savedLevel;
         this.player.xp = savedXP;
         this.player.weaponManager = savedWeaponManager;
+        this.player.perks = savedPerks;
+        this.player.levelBonuses = savedLevelBonuses;
+        this.player.maxHealth = 100 + savedLevelBonuses.maxHealthBonus + this.player.getPerkStacks('thick_skin') * 25;
+        this.player.maxArmor = 100 + this.player.getPerkStacks('iron_will') * 15;
 
         // Reset per-level stats but keep cumulative
         this.player.stats = {
@@ -1521,6 +1537,11 @@ class GameEngine {
             this.renderModSelection();
         }
 
+        // Render perk selection screen
+        if (this.perkSelection.active) {
+            this.renderPerkSelection();
+        }
+
         // Render death stats screen
         if (this.showDeathScreen) {
             this.renderDeathScreen();
@@ -1948,7 +1969,7 @@ class GameEngine {
     }
 
     isMenuOpen() {
-        return this.paused || this.levelComplete || this.showDeathScreen || this.intermission.active || this.modSelection.active;
+        return this.paused || this.levelComplete || this.showDeathScreen || this.intermission.active || this.modSelection.active || this.perkSelection.active;
     }
     
     getCurrentState() {
@@ -1982,6 +2003,189 @@ class GameEngine {
         this.inputManager.update();
     }
 
+    showPerkSelection() {
+        const pool = GameEngine.PERK_POOL;
+        // Pick 3 random unique perks
+        const choices = [];
+        const indices = [];
+        while (choices.length < 3 && indices.length < pool.length) {
+            const idx = Math.floor(Math.random() * pool.length);
+            if (!indices.includes(idx)) {
+                indices.push(idx);
+                choices.push(pool[idx]);
+            }
+        }
+
+        this.perkSelection = { active: true, choices, hoveredIndex: -1 };
+
+        // Release pointer lock for menu interaction
+        if (document.pointerLockElement) {
+            document.exitPointerLock();
+        }
+
+        // Attach click/hover handlers (once)
+        if (!this._perkClickBound) {
+            this._perkClickBound = true;
+            this.canvas.addEventListener('click', (e) => {
+                if (!this.perkSelection.active) return;
+                const rect = this.canvas.getBoundingClientRect();
+                const scaleX = this.canvas.width / rect.width;
+                const scaleY = this.canvas.height / rect.height;
+                const mx = (e.clientX - rect.left) * scaleX;
+                const my = (e.clientY - rect.top) * scaleY;
+
+                for (let i = 0; i < this.perkSelection.choices.length; i++) {
+                    const btn = this._perkBtns && this._perkBtns[i];
+                    if (btn && mx >= btn.x && mx <= btn.x + btn.w && my >= btn.y && my <= btn.y + btn.h) {
+                        this.selectPerk(i);
+                        return;
+                    }
+                }
+            });
+
+            this.canvas.addEventListener('mousemove', (e) => {
+                if (!this.perkSelection.active) return;
+                const rect = this.canvas.getBoundingClientRect();
+                const scaleX = this.canvas.width / rect.width;
+                const scaleY = this.canvas.height / rect.height;
+                const mx = (e.clientX - rect.left) * scaleX;
+                const my = (e.clientY - rect.top) * scaleY;
+
+                this.perkSelection.hoveredIndex = -1;
+                for (let i = 0; i < this.perkSelection.choices.length; i++) {
+                    const btn = this._perkBtns && this._perkBtns[i];
+                    if (btn && mx >= btn.x && mx <= btn.x + btn.w && my >= btn.y && my <= btn.y + btn.h) {
+                        this.perkSelection.hoveredIndex = i;
+                        break;
+                    }
+                }
+            });
+        }
+    }
+
+    selectPerk(index) {
+        const perk = this.perkSelection.choices[index];
+        if (!perk) return;
+
+        this.player.applyPerk(perk);
+
+        if (window.soundEngine && window.soundEngine.isInitialized) {
+            window.soundEngine.playPickup('health');
+        }
+
+        if (this.hud && this.hud.addKillFeedMessage) {
+            const stacks = this.player.getPerkStacks(perk.id);
+            const stackLabel = stacks > 1 ? ` x${stacks}` : '';
+            this.hud.addKillFeedMessage(`PERK: ${perk.name}${stackLabel}`, perk.color);
+        }
+
+        this.perkSelection.active = false;
+    }
+
+    renderPerkSelection() {
+        const ctx = this.canvas.getContext('2d');
+        const w = this.canvas.width;
+        const h = this.canvas.height;
+        const choices = this.perkSelection.choices;
+
+        // Dark overlay
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.85)';
+        ctx.fillRect(0, 0, w, h);
+
+        // Header
+        ctx.textAlign = 'center';
+        ctx.fillStyle = '#FFD700';
+        ctx.font = 'bold 28px monospace';
+        ctx.fillText('LEVEL UP!', w / 2, h * 0.10);
+
+        ctx.fillStyle = '#AAAAAA';
+        ctx.font = '14px monospace';
+        ctx.fillText(`Level ${this.player.level} — Choose a perk`, w / 2, h * 0.16);
+
+        // Perk cards
+        const cardW = 200;
+        const cardH = 180;
+        const gap = 24;
+        const totalW = choices.length * cardW + (choices.length - 1) * gap;
+        const startX = (w - totalW) / 2;
+        const cardY = h * 0.22;
+        this._perkBtns = [];
+
+        for (let i = 0; i < choices.length; i++) {
+            const perk = choices[i];
+            const cx = startX + i * (cardW + gap);
+            const isHovered = this.perkSelection.hoveredIndex === i;
+
+            this._perkBtns.push({ x: cx, y: cardY, w: cardW, h: cardH });
+
+            // Card background
+            ctx.fillStyle = isHovered ? 'rgba(40, 40, 60, 0.95)' : 'rgba(20, 20, 30, 0.9)';
+            ctx.fillRect(cx, cardY, cardW, cardH);
+
+            // Border
+            ctx.strokeStyle = isHovered ? perk.color : '#444444';
+            ctx.lineWidth = isHovered ? 2 : 1;
+            ctx.strokeRect(cx, cardY, cardW, cardH);
+
+            // Color bar at top
+            ctx.fillStyle = perk.color;
+            ctx.fillRect(cx, cardY, cardW, 4);
+
+            // Icon
+            ctx.fillStyle = perk.color;
+            ctx.font = 'bold 32px monospace';
+            ctx.textAlign = 'center';
+            ctx.fillText(perk.icon, cx + cardW / 2, cardY + 48);
+
+            // Perk name
+            ctx.fillStyle = '#FFFFFF';
+            ctx.font = 'bold 16px monospace';
+            ctx.fillText(perk.name, cx + cardW / 2, cardY + 80);
+
+            // Description
+            ctx.fillStyle = '#AAAAAA';
+            ctx.font = '12px monospace';
+            ctx.fillText(perk.desc, cx + cardW / 2, cardY + 104);
+
+            // Current stacks
+            const stacks = this.player.getPerkStacks(perk.id);
+            if (stacks > 0) {
+                ctx.fillStyle = perk.color;
+                ctx.font = '11px monospace';
+                ctx.fillText(`Currently: x${stacks}`, cx + cardW / 2, cardY + 128);
+            }
+
+            // Hover hint
+            if (isHovered) {
+                ctx.fillStyle = '#FFFFFF';
+                ctx.font = 'bold 12px monospace';
+                ctx.fillText('CLICK TO SELECT', cx + cardW / 2, cardY + cardH - 14);
+            }
+        }
+
+        // Active perks summary
+        this.renderActivePerksSummary(ctx, w, h);
+    }
+
+    renderActivePerksSummary(ctx, w, h) {
+        const perks = this.player.getActivePerks();
+        if (perks.length === 0) return;
+
+        ctx.textAlign = 'center';
+        ctx.fillStyle = '#666666';
+        ctx.font = '11px monospace';
+        ctx.fillText('ACTIVE PERKS', w / 2, h * 0.78);
+
+        let y = h * 0.82;
+        ctx.font = '10px monospace';
+        for (const perk of perks) {
+            const stackLabel = perk.stacks > 1 ? ` x${perk.stacks}` : '';
+            ctx.fillStyle = perk.color;
+            ctx.fillText(`${perk.name}${stackLabel}`, w / 2, y);
+            y += 14;
+        }
+    }
+
     renderPauseMenu() {
         const ctx = this.canvas.getContext('2d');
         const w = this.canvas.width;
@@ -1993,7 +2197,7 @@ class GameEngine {
 
         // Menu box
         const menuW = 300;
-        const menuH = 380;
+        const menuH = 420;
         const menuX = (w - menuW) / 2;
         const menuY = (h - menuH) / 2;
 
@@ -2091,6 +2295,28 @@ class GameEngine {
             }
         }
 
+        // Active perks section
+        const perks = this.player.getActivePerks();
+        if (perks.length > 0) {
+            let perkY = itemStartY + items.length * itemH + 8;
+            // Offset below mods if present
+            if (modCount > 0) {
+                perkY += 14 + Object.values(wm.weapons).filter(w => w.mods.length > 0).length * 12 + 8;
+            }
+            ctx.fillStyle = '#00FF88';
+            ctx.font = 'bold 11px monospace';
+            ctx.textAlign = 'center';
+            ctx.fillText('PERKS', w / 2, perkY);
+            perkY += 14;
+            ctx.font = '10px monospace';
+            for (const perk of perks) {
+                const stackLabel = perk.stacks > 1 ? ` x${perk.stacks}` : '';
+                ctx.fillStyle = perk.color;
+                ctx.fillText(`${perk.name}${stackLabel}`, w / 2, perkY);
+                perkY += 12;
+            }
+        }
+
         // Controls hint at bottom
         ctx.fillStyle = '#666666';
         ctx.font = '11px monospace';
@@ -2123,6 +2349,18 @@ class GameEngine {
         console.log('Game engine destroyed');
     }
 }
+
+// Perk pool definitions
+GameEngine.PERK_POOL = [
+    { id: 'thick_skin', name: 'Thick Skin', desc: '+25 max HP', color: '#FF4444', icon: '♥' },
+    { id: 'quick_feet', name: 'Quick Feet', desc: '+10% movement speed', color: '#00CCFF', icon: '»' },
+    { id: 'scavenger', name: 'Scavenger', desc: '+50% ammo from pickups', color: '#FFAA00', icon: '⬡' },
+    { id: 'iron_will', name: 'Iron Will', desc: '+15 max armor', color: '#4488FF', icon: '⛨' },
+    { id: 'adrenaline', name: 'Adrenaline', desc: '+20% stamina regen', color: '#FF8800', icon: '↑' },
+    { id: 'steady_aim', name: 'Steady Aim', desc: '-25% weapon bloom', color: '#00FF88', icon: '◎' },
+    { id: 'vampiric', name: 'Vampiric', desc: '5% lifesteal on kills', color: '#CC00FF', icon: '☽' },
+    { id: 'second_wind', name: 'Second Wind', desc: '+1 HP/s regen below 25% HP', color: '#FF88CC', icon: '♺' }
+];
 
 // Export to global scope
 window.GameEngine = GameEngine;

--- a/js/entities/pickup.js
+++ b/js/entities/pickup.js
@@ -222,10 +222,14 @@ class Pickup {
     
     collect(player) {
         if (this.collected) return;
-        
+
         let canCollect = false;
         const props = this.properties;
-        
+
+        // Scavenger perk: multiply ammo pickup values
+        const scavengerStacks = player.getPerkStacks ? player.getPerkStacks('scavenger') : 0;
+        const ammoMultiplier = 1 + scavengerStacks * 0.5;
+
         switch (this.type) {
             case 'health':
             case 'health_large':
@@ -237,35 +241,35 @@ class Pickup {
                 
             case 'ammo_pistol':
                 if (player.weaponManager.weapons.pistol.maxAmmo > 0) {
-                    player.weaponManager.weapons.pistol.maxAmmo += props.value;
+                    player.weaponManager.weapons.pistol.maxAmmo += Math.round(props.value * ammoMultiplier);
                     canCollect = true;
                 }
                 break;
-                
+
             case 'ammo_shotgun':
                 if (player.weaponManager.weapons.shotgun.maxAmmo > 0) {
-                    player.weaponManager.weapons.shotgun.maxAmmo += props.value;
+                    player.weaponManager.weapons.shotgun.maxAmmo += Math.round(props.value * ammoMultiplier);
                     canCollect = true;
                 }
                 break;
-                
+
             case 'ammo_rifle':
                 if (player.weaponManager.weapons.rifle.maxAmmo > 0) {
-                    player.weaponManager.weapons.rifle.maxAmmo += props.value;
+                    player.weaponManager.weapons.rifle.maxAmmo += Math.round(props.value * ammoMultiplier);
                     canCollect = true;
                 }
                 break;
 
             case 'ammo_rocket':
                 if (player.weaponManager.weapons.rocket) {
-                    player.weaponManager.weapons.rocket.maxAmmo += props.value;
+                    player.weaponManager.weapons.rocket.maxAmmo += Math.round(props.value * ammoMultiplier);
                     canCollect = true;
                 }
                 break;
 
             case 'ammo_chaingun':
                 if (player.weaponManager.weapons.chaingun) {
-                    player.weaponManager.weapons.chaingun.maxAmmo += props.value;
+                    player.weaponManager.weapons.chaingun.maxAmmo += Math.round(props.value * ammoMultiplier);
                     canCollect = true;
                 }
                 break;

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -64,6 +64,10 @@ class Player {
             speedBonus: 0
         };
 
+        // Perk system (reset on death/restart, persist across floors)
+        this.perks = []; // Array of { id, name, color, stacks }
+        this.pendingPerkSelection = false;
+
         // Weapon system
         this.weaponManager = new WeaponManager();
 
@@ -323,6 +327,9 @@ class Player {
 
         // Update power-up effects
         this.updatePowerupEffects();
+
+        // Update perk effects (Second Wind HP regen)
+        this.updatePerkEffects(deltaTime);
 
         // Update other systems
         this.updatePhysics(deltaTime);
@@ -610,6 +617,7 @@ class Player {
                 const xpReward = Math.round((xpTable[closestEnemy.type] || 20) * eliteBonus * xpMultiplier);
                 if (this.addXP) this.addXP(xpReward);
                 this.registerKill();
+                this.onKillForPerks(closestEnemy);
 
                 // Kill feed message for punch kills
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
@@ -1049,10 +1057,13 @@ class Player {
         this.levelBonuses.speedBonus += 5;
 
         // Apply bonuses
-        this.maxHealth = 100 + this.levelBonuses.maxHealthBonus;
+        this.maxHealth = 100 + this.levelBonuses.maxHealthBonus + this.getPerkStacks('thick_skin') * 25;
         this.health = Math.min(this.health + 20, this.maxHealth); // Heal 20 on level up
         this.baseSpeed = 200 + this.levelBonuses.speedBonus;
         this.speed = this.baseSpeed;
+
+        // Trigger perk selection
+        this.pendingPerkSelection = true;
 
         // Kill feed message for level up
         if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
@@ -1083,6 +1094,75 @@ class Player {
             corridor: 'stone'
         };
         return profileToSurface[profile] || 'stone';
+    }
+
+    // Perk system methods
+    getPerkStacks(perkId) {
+        const perk = this.perks.find(p => p.id === perkId);
+        return perk ? perk.stacks : 0;
+    }
+
+    applyPerk(perkDef) {
+        const existing = this.perks.find(p => p.id === perkDef.id);
+        if (existing) {
+            existing.stacks++;
+        } else {
+            this.perks.push({ id: perkDef.id, name: perkDef.name, color: perkDef.color, stacks: 1 });
+        }
+
+        // Apply immediate stat changes
+        switch (perkDef.id) {
+            case 'thick_skin':
+                this.maxHealth += 25;
+                this.health = Math.min(this.health + 25, this.maxHealth);
+                break;
+            case 'quick_feet':
+                this.baseSpeed = Math.round(this.baseSpeed * 1.10);
+                this.speed = this.baseSpeed;
+                break;
+            case 'iron_will':
+                this.maxArmor += 15;
+                this.armor = Math.min(this.armor + 15, this.maxArmor);
+                break;
+            case 'adrenaline':
+                this.staminaRegenRate = Math.round(this.staminaRegenRate * 1.20);
+                break;
+            case 'steady_aim':
+                // Applied in weapon.js bloom calculation via getPerkStacks
+                break;
+            case 'scavenger':
+                // Applied in pickup collection via getPerkStacks
+                break;
+            case 'vampiric':
+                // Applied on kill via getPerkStacks
+                break;
+            case 'second_wind':
+                // Applied in update loop via getPerkStacks
+                break;
+        }
+
+        this.pendingPerkSelection = false;
+    }
+
+    updatePerkEffects(deltaTime) {
+        // Second Wind: regen HP when below 25%
+        const secondWindStacks = this.getPerkStacks('second_wind');
+        if (secondWindStacks > 0 && this.health > 0 && this.health <= this.maxHealth * 0.25) {
+            this.health = Math.min(this.maxHealth, this.health + secondWindStacks * deltaTime);
+        }
+    }
+
+    onKillForPerks(enemy) {
+        // Vampiric: heal 5% of enemy max HP per stack
+        const vampStacks = this.getPerkStacks('vampiric');
+        if (vampStacks > 0) {
+            const healAmount = Math.max(1, Math.round(enemy.maxHealth * 0.05 * vampStacks));
+            this.health = Math.min(this.maxHealth, this.health + healAmount);
+        }
+    }
+
+    getActivePerks() {
+        return this.perks.slice();
     }
 
     // Debug methods

--- a/js/weapons/weapon.js
+++ b/js/weapons/weapon.js
@@ -218,6 +218,7 @@ class Weapon {
                 const xpReward = this.getKillXP(hit.enemy);
                 if (player.addXP) player.addXP(xpReward);
                 if (player.registerKill) player.registerKill();
+                if (player.onKillForPerks) player.onKillForPerks(hit.enemy);
 
                 // Kill feed message with weapon name
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
@@ -378,8 +379,11 @@ class Weapon {
         const rayX = player.x;
         const rayY = player.y;
         // Apply bloom spread: random angle offset within bloom cone
-        const bloomSpread = this.bloomLevel > 0
-            ? (Math.random() - 0.5) * 2 * this.bloomLevel
+        // Steady Aim perk reduces bloom by 25% per stack
+        const steadyAimReduction = player.getPerkStacks ? (1 - player.getPerkStacks('steady_aim') * 0.25) : 1;
+        const effectiveBloom = this.bloomLevel * Math.max(0, steadyAimReduction);
+        const bloomSpread = effectiveBloom > 0
+            ? (Math.random() - 0.5) * 2 * effectiveBloom
             : 0;
         const rayAngle = player.angle + bloomSpread;
         const rayDirX = Math.cos(rayAngle);
@@ -652,6 +656,7 @@ class Weapon {
                 const xpReward = this.getKillXP(hit.enemy);
                 if (player.addXP) player.addXP(xpReward);
                 if (player.registerKill) player.registerKill();
+                if (player.onKillForPerks) player.onKillForPerks(hit.enemy);
                 if (window.game && window.game.hud && window.game.hud.addKillFeedMessage) {
                     const typeName = (hit.enemy.type || 'enemy').charAt(0).toUpperCase() + (hit.enemy.type || 'enemy').slice(1);
                     const eliteTag = hit.enemy.isElite ? ' [ELITE]' : '';
@@ -753,6 +758,7 @@ class Weapon {
                 const xpReward = this.getKillXP(hit.enemy);
                 if (player.addXP) player.addXP(xpReward);
                 if (player.registerKill) player.registerKill();
+                if (player.onKillForPerks) player.onKillForPerks(hit.enemy);
             }
             hit.enemy.hitFlashTime = Date.now();
             if (isHeadshot && window.soundEngine && window.soundEngine.isInitialized && window.soundEngine.playHeadshot) {

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -632,6 +632,7 @@ const TIER_2_TESTS = [
   { id: 'T2-42', name: 'Enemy morale and retreat behavior', fn: T2_42_enemyMorale }, // issue: #315
   { id: 'T2-43', name: 'Weapon reload animation', fn: T2_43_reloadAnimation }, // issue: #316
   { id: 'T2-44', name: 'Weapon modification system', fn: T2_44_weaponModSystem }, // issue: #321
+  { id: 'T2-45', name: 'Level-up perk selection system', fn: T2_45_perkSelectionSystem }, // issue: #322
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -3460,6 +3461,117 @@ async function T2_44_weaponModSystem(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Weapon mod system: ${modData.modIds.length} mods, selection screen, all mod types functional`;
+  }
+}
+
+async function T2_45_perkSelectionSystem(page, result) {
+  const perkData = await page.evaluate(() => {
+    if (!window.game || !window.game.player) {
+      return { exists: false, reason: 'No game/player' };
+    }
+
+    const player = window.game.player;
+
+    // Check PERK_POOL exists
+    const hasPerkPool = Array.isArray(GameEngine.PERK_POOL) && GameEngine.PERK_POOL.length >= 8;
+    const perkIds = hasPerkPool ? GameEngine.PERK_POOL.map(p => p.id) : [];
+
+    // Check player perk arrays/methods
+    const hasPerksArray = Array.isArray(player.perks);
+    const hasApplyPerk = typeof player.applyPerk === 'function';
+    const hasGetPerkStacks = typeof player.getPerkStacks === 'function';
+    const hasGetActivePerks = typeof player.getActivePerks === 'function';
+    const hasOnKillForPerks = typeof player.onKillForPerks === 'function';
+
+    // Test applyPerk: Thick Skin
+    const origMaxHP = player.maxHealth;
+    const origPerks = player.perks.slice();
+    player.applyPerk({ id: 'thick_skin', name: 'Thick Skin', color: '#FF4444' });
+    const thickSkinApplied = player.maxHealth === origMaxHP + 25;
+    const thickSkinStacks = player.getPerkStacks('thick_skin') === 1;
+
+    // Test stacking
+    player.applyPerk({ id: 'thick_skin', name: 'Thick Skin', color: '#FF4444' });
+    const stacksTo2 = player.getPerkStacks('thick_skin') === 2;
+
+    // Test Iron Will
+    const origMaxArmor = player.maxArmor;
+    player.applyPerk({ id: 'iron_will', name: 'Iron Will', color: '#4488FF' });
+    const ironWillApplied = player.maxArmor === origMaxArmor + 15;
+
+    // Test getActivePerks
+    const activePerks = player.getActivePerks();
+    const activePerksCorrect = activePerks.length >= 2;
+
+    // Check game methods
+    const hasShowPerkSelection = typeof window.game.showPerkSelection === 'function';
+    const hasRenderPerkSelection = typeof window.game.renderPerkSelection === 'function';
+    const hasPerkSelectionState = window.game.perkSelection !== undefined;
+
+    // Check isMenuOpen includes perkSelection
+    window.game.perkSelection.active = true;
+    const menuOpenWithPerk = window.game.isMenuOpen() === true;
+    window.game.perkSelection.active = false;
+
+    // Restore player state
+    player.perks = origPerks;
+    player.maxHealth = origMaxHP;
+    player.maxArmor = origMaxArmor;
+    player.pendingPerkSelection = false;
+
+    return {
+      exists: true,
+      hasPerkPool,
+      perkIds,
+      hasPerksArray,
+      hasApplyPerk,
+      hasGetPerkStacks,
+      hasGetActivePerks,
+      hasOnKillForPerks,
+      thickSkinApplied,
+      thickSkinStacks,
+      stacksTo2,
+      ironWillApplied,
+      activePerksCorrect,
+      hasShowPerkSelection,
+      hasRenderPerkSelection,
+      hasPerkSelectionState,
+      menuOpenWithPerk
+    };
+  });
+
+  if (!perkData.exists) {
+    result.status = 'fail';
+    result.note = perkData.reason;
+    return;
+  }
+
+  const checks = [
+    ['PERK_POOL with 8+ perks', perkData.hasPerkPool],
+    ['perks array on player', perkData.hasPerksArray],
+    ['applyPerk method', perkData.hasApplyPerk],
+    ['getPerkStacks method', perkData.hasGetPerkStacks],
+    ['getActivePerks method', perkData.hasGetActivePerks],
+    ['onKillForPerks method', perkData.hasOnKillForPerks],
+    ['Thick Skin adds 25 max HP', perkData.thickSkinApplied],
+    ['perk stacks to 1', perkData.thickSkinStacks],
+    ['perk stacks to 2', perkData.stacksTo2],
+    ['Iron Will adds 15 max armor', perkData.ironWillApplied],
+    ['getActivePerks returns perks', perkData.activePerksCorrect],
+    ['showPerkSelection method', perkData.hasShowPerkSelection],
+    ['renderPerkSelection method', perkData.hasRenderPerkSelection],
+    ['perkSelection state object', perkData.hasPerkSelectionState],
+    ['isMenuOpen includes perks', perkData.menuOpenWithPerk]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Perk system: ${perkData.perkIds.length} perks, selection UI, stacking, stat bonuses`;
   }
 }
 


### PR DESCRIPTION
## Summary
- On level-up, pauses game and presents 3 random perks from a pool of 8
- Perks: Thick Skin, Quick Feet, Scavenger, Iron Will, Adrenaline, Steady Aim, Vampiric, Second Wind
- Perks stack if chosen again, persist across floors, reset on death/restart
- Active perks displayed in pause menu
- Selection UI follows existing mod selection pattern (click cards)

## Test plan
- [x] T2-45 automated test passes (perk pool, apply, stack, stat bonuses, UI methods)
- [x] All existing tests pass (52 pass, 2 known flaky, 3 skipped)

Fixes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)