### PR TITLE
Add persistent lifetime statistics and achievements

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -43,6 +43,8 @@ class GameEngine {
         // High score persistence
         this.STORAGE_KEY = 'dailydoom_highscores';
         this.BEST_RUN_KEY = 'dailydoom_bestrun';
+        this.LIFETIME_STATS_KEY = 'dailydoom_lifetime_stats';
+        this.ACHIEVEMENTS_KEY = 'dailydoom_achievements';
         this.currentScore = 0;
         this.showDeathScreen = false;
         this.deathScreenTime = 0;
@@ -773,6 +775,103 @@ class GameEngine {
         }
     }
 
+    // ========== LIFETIME STATS & ACHIEVEMENTS ==========
+
+    getLifetimeStats() {
+        try {
+            const data = localStorage.getItem(this.LIFETIME_STATS_KEY);
+            return data ? JSON.parse(data) : null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    accumulateLifetimeStats(elapsed) {
+        try {
+            const prev = this.getLifetimeStats() || {
+                totalKills: 0, totalFloors: 0, totalRuns: 0,
+                bestFloor: 0, totalXP: 0, totalHeadshots: 0,
+                totalGloryKills: 0, highestCombo: 0, timePlayed: 0,
+                weaponsUsed: []
+            };
+            const stats = this.player.stats;
+            const comboInfo = this.player.getComboInfo ? this.player.getComboInfo() : null;
+
+            prev.totalKills += stats.enemiesKilled;
+            prev.totalFloors += Math.max(0, (this.currentLevel || 1) - 1);
+            prev.totalRuns++;
+            prev.bestFloor = Math.max(prev.bestFloor, this.currentLevel || 1);
+            prev.totalXP += this.player.xp || 0;
+            prev.totalHeadshots += stats.headshots || 0;
+            prev.totalGloryKills += stats.gloryKills || 0;
+            prev.highestCombo = Math.max(prev.highestCombo, comboInfo ? comboInfo.bestStreak : 0);
+            prev.timePlayed += Math.floor(elapsed);
+
+            // Track weapons used this run
+            const wm = this.player.weaponManager;
+            if (wm && wm.unlockedWeapons) {
+                const used = Array.from(wm.unlockedWeapons);
+                for (const w of used) {
+                    if (!prev.weaponsUsed.includes(w)) prev.weaponsUsed.push(w);
+                }
+            }
+
+            localStorage.setItem(this.LIFETIME_STATS_KEY, JSON.stringify(prev));
+
+            // Check achievements after accumulating
+            this.checkAchievements(prev);
+        } catch (e) {
+            console.error('Failed to save lifetime stats:', e);
+        }
+    }
+
+    getAchievements() {
+        try {
+            const data = localStorage.getItem(this.ACHIEVEMENTS_KEY);
+            return data ? JSON.parse(data) : {};
+        } catch (e) {
+            return {};
+        }
+    }
+
+    checkAchievements(lifetime) {
+        const unlocked = this.getAchievements();
+        const newUnlocks = [];
+
+        const checks = [
+            { id: 'first_blood', name: 'First Blood', desc: 'Kill your first enemy', test: () => lifetime.totalKills >= 1 },
+            { id: 'floor_clearer', name: 'Floor Clearer', desc: 'Clear 10 floors total', test: () => lifetime.totalFloors >= 10 },
+            { id: 'marksman', name: 'Marksman', desc: 'Get 100 headshots', test: () => lifetime.totalHeadshots >= 100 },
+            { id: 'executioner', name: 'Executioner', desc: 'Perform 50 glory kills', test: () => lifetime.totalGloryKills >= 50 },
+            { id: 'unstoppable', name: 'Unstoppable', desc: 'Reach floor 5 in a single run', test: () => lifetime.bestFloor >= 5 },
+            { id: 'kill_streak', name: 'Kill Streak', desc: 'Get a 10x combo', test: () => lifetime.highestCombo >= 10 },
+            { id: 'arsenal', name: 'Arsenal', desc: 'Use all 6 weapons in a single run', test: () => {
+                const wm = this.player.weaponManager;
+                return wm && wm.unlockedWeapons && wm.unlockedWeapons.size >= 6;
+            }},
+            { id: 'veteran', name: 'Veteran', desc: 'Complete 10 runs', test: () => lifetime.totalRuns >= 10 },
+            { id: 'centurion', name: 'Centurion', desc: 'Kill 100 enemies total', test: () => lifetime.totalKills >= 100 },
+            { id: 'slayer', name: 'Slayer', desc: 'Kill 500 enemies total', test: () => lifetime.totalKills >= 500 }
+        ];
+
+        for (const ach of checks) {
+            if (!unlocked[ach.id] && ach.test()) {
+                unlocked[ach.id] = Date.now();
+                newUnlocks.push(ach);
+            }
+        }
+
+        if (newUnlocks.length > 0) {
+            localStorage.setItem(this.ACHIEVEMENTS_KEY, JSON.stringify(unlocked));
+            // Show achievement notifications
+            for (const ach of newUnlocks) {
+                if (this.hud && this.hud.addKillFeedMessage) {
+                    this.hud.addKillFeedMessage(`ACHIEVEMENT: ${ach.name}`, '#FFD700');
+                }
+            }
+        }
+    }
+
     // ========== DEATH SCREEN ==========
 
     onPlayerDeath() {
@@ -792,6 +891,9 @@ class GameEngine {
         const elapsed = (performance.now() - this.levelStartTime) / 1000;
         this._deathNewBests = this.saveBestRun(this.player.stats, elapsed);
         this._deathElapsed = elapsed;
+
+        // Accumulate lifetime stats
+        this.accumulateLifetimeStats(elapsed);
     }
 
     renderDeathScreen() {
@@ -872,6 +974,18 @@ class GameEngine {
                 ctx.font = '16px monospace';
             }
             y += lineH + (bestKey && newBests[bestKey] ? 10 : 0);
+        }
+
+        // Lifetime stats summary line
+        const lifetime = this.getLifetimeStats();
+        if (lifetime) {
+            ctx.fillStyle = '#666666';
+            ctx.font = '11px monospace';
+            ctx.textAlign = 'center';
+            ctx.fillText(
+                `LIFETIME: ${lifetime.totalKills} kills | ${lifetime.totalRuns} runs | ${lifetime.bestFloor} best floor`,
+                w / 2, panelY + panelH - 8
+            );
         }
 
         // Restart button
@@ -1035,6 +1149,7 @@ class GameEngine {
         // Reset per-level stats but keep cumulative
         this.player.stats = {
             enemiesKilled: 0, shotsFired: 0, shotsHit: 0, headshots: 0,
+            criticalHits: 0, gloryKills: 0,
             damageTaken: 0, damageDealt: 0, itemsCollected: 0,
             deaths: 0, timeSurvived: 0
         };

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -50,6 +50,7 @@ class Player {
             shotsHit: 0,
             headshots: 0,
             criticalHits: 0,
+            gloryKills: 0,
             damageTaken: 0,
             damageDealt: 0,
             itemsCollected: 0,
@@ -611,6 +612,7 @@ class Player {
 
             if (wasAlive && !closestEnemy.active) {
                 if (this.stats) this.stats.enemiesKilled++;
+                if (isGloryKill && this.stats) this.stats.gloryKills++;
                 const xpTable = { imp: 15, guard: 20, soldier: 30, demon: 40, berserker: 35, spitter: 25, shield_guard: 45, boss: 200 };
                 const eliteBonus = closestEnemy.isElite ? 1.5 : 1.0;
                 const xpMultiplier = isGloryKill ? 2.0 : 1.0;

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -633,6 +633,7 @@ const TIER_2_TESTS = [
   { id: 'T2-43', name: 'Weapon reload animation', fn: T2_43_reloadAnimation }, // issue: #316
   { id: 'T2-44', name: 'Weapon modification system', fn: T2_44_weaponModSystem }, // issue: #321
   { id: 'T2-45', name: 'Level-up perk selection system', fn: T2_45_perkSelectionSystem }, // issue: #322
+  { id: 'T2-46', name: 'Lifetime stats and achievements', fn: T2_46_lifetimeStatsAchievements }, // issue: #323
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -3572,6 +3573,116 @@ async function T2_45_perkSelectionSystem(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Perk system: ${perkData.perkIds.length} perks, selection UI, stacking, stat bonuses`;
+  }
+}
+
+async function T2_46_lifetimeStatsAchievements(page, result) {
+  const data = await page.evaluate(() => {
+    if (!window.game || !window.game.player) {
+      return { exists: false, reason: 'No game/player' };
+    }
+
+    const game = window.game;
+
+    // Check storage keys
+    const hasLifetimeKey = typeof game.LIFETIME_STATS_KEY === 'string';
+    const hasAchievementsKey = typeof game.ACHIEVEMENTS_KEY === 'string';
+
+    // Check methods
+    const hasGetLifetimeStats = typeof game.getLifetimeStats === 'function';
+    const hasAccumulate = typeof game.accumulateLifetimeStats === 'function';
+    const hasGetAchievements = typeof game.getAchievements === 'function';
+    const hasCheckAchievements = typeof game.checkAchievements === 'function';
+
+    // Check player.stats has gloryKills
+    const hasGloryKills = 'gloryKills' in game.player.stats;
+
+    // Test accumulation: simulate a run's worth of stats
+    const origStats = Object.assign({}, game.player.stats);
+    game.player.stats.enemiesKilled = 5;
+    game.player.stats.headshots = 2;
+    game.player.stats.gloryKills = 1;
+
+    // Clear previous lifetime data for clean test
+    const prevLifetime = localStorage.getItem(game.LIFETIME_STATS_KEY);
+    const prevAchievements = localStorage.getItem(game.ACHIEVEMENTS_KEY);
+    localStorage.removeItem(game.LIFETIME_STATS_KEY);
+    localStorage.removeItem(game.ACHIEVEMENTS_KEY);
+
+    game.accumulateLifetimeStats(60);
+    const lifetime = game.getLifetimeStats();
+    const statsAccumulated = lifetime && lifetime.totalKills === 5 && lifetime.totalRuns === 1;
+    const headshotsTracked = lifetime && lifetime.totalHeadshots === 2;
+    const gloryKillsTracked = lifetime && lifetime.totalGloryKills === 1;
+
+    // Check achievements were awarded
+    const achievements = game.getAchievements();
+    const firstBloodUnlocked = achievements && achievements.first_blood > 0;
+
+    // Accumulate again to test additive behavior
+    game.accumulateLifetimeStats(30);
+    const lifetime2 = game.getLifetimeStats();
+    const additive = lifetime2 && lifetime2.totalKills === 10 && lifetime2.totalRuns === 2;
+
+    // Restore
+    game.player.stats = origStats;
+    if (prevLifetime) {
+      localStorage.setItem(game.LIFETIME_STATS_KEY, prevLifetime);
+    } else {
+      localStorage.removeItem(game.LIFETIME_STATS_KEY);
+    }
+    if (prevAchievements) {
+      localStorage.setItem(game.ACHIEVEMENTS_KEY, prevAchievements);
+    } else {
+      localStorage.removeItem(game.ACHIEVEMENTS_KEY);
+    }
+
+    return {
+      exists: true,
+      hasLifetimeKey,
+      hasAchievementsKey,
+      hasGetLifetimeStats,
+      hasAccumulate,
+      hasGetAchievements,
+      hasCheckAchievements,
+      hasGloryKills,
+      statsAccumulated,
+      headshotsTracked,
+      gloryKillsTracked,
+      firstBloodUnlocked,
+      additive
+    };
+  });
+
+  if (!data.exists) {
+    result.status = 'fail';
+    result.note = data.reason;
+    return;
+  }
+
+  const checks = [
+    ['LIFETIME_STATS_KEY defined', data.hasLifetimeKey],
+    ['ACHIEVEMENTS_KEY defined', data.hasAchievementsKey],
+    ['getLifetimeStats method', data.hasGetLifetimeStats],
+    ['accumulateLifetimeStats method', data.hasAccumulate],
+    ['getAchievements method', data.hasGetAchievements],
+    ['checkAchievements method', data.hasCheckAchievements],
+    ['gloryKills in player.stats', data.hasGloryKills],
+    ['stats accumulated correctly', data.statsAccumulated],
+    ['headshots tracked', data.headshotsTracked],
+    ['glory kills tracked', data.gloryKillsTracked],
+    ['First Blood achievement unlocked', data.firstBloodUnlocked],
+    ['stats additive across runs', data.additive]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = 'Lifetime stats: accumulation, headshots, glory kills, achievements';
   }
 }
 


### PR DESCRIPTION
## Summary
- Tracks cumulative stats across all runs in localStorage (kills, floors, headshots, glory kills, combo, time played)
- 10 achievements: First Blood, Floor Clearer, Marksman, Executioner, Unstoppable, Kill Streak, Arsenal, Veteran, Centurion, Slayer
- Achievement unlock notifications shown via kill feed
- Lifetime stats summary on death screen
- Glory kill counter added to player stats tracking

## Test plan
- [x] T2-46 automated test passes (accumulation, headshots, glory kills, achievements, additive behavior)
- [x] All existing tests pass (53 pass, 2 known flaky, 3 skipped)

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)