### PR TITLE
Add .autodev/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,8 @@ npm-debug.log*
 *.tmp
 *.temp
 
+# Automation tooling
+.autodev/
+
 # Playtester
 playtester/node_modules/


### PR DESCRIPTION
## Summary
- Adds `.autodev/` directory to `.gitignore` to prevent automation state files from being tracked

## Test plan
- [x] Simple config change, no code affected

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)