### PR TITLE
Add procedural floor blood splatters on kill

### DIFF
--- a/js/engine/game.js
+++ b/js/engine/game.js
@@ -1188,8 +1188,11 @@ class GameEngine {
             this.hud.resetFog();
         }
 
-        // Update renderer with new map
+        // Update renderer with new map and clear floor splatters
         this.renderer.map = this.map;
+        if (this.renderer.clearFloorSplatters) {
+            this.renderer.clearFloorSplatters();
+        }
 
         this.totalEnemyCount = this.map.enemies.length;
         this.levelStartTime = performance.now();

--- a/js/engine/renderer.js
+++ b/js/engine/renderer.js
@@ -58,6 +58,11 @@ class Renderer {
         this._staticLightDirty = true;
         this.dynamicLights = []; // Transient lights (muzzle flash, explosions)
 
+        // Floor blood splatters
+        this.floorSplatters = [];
+        this.floorSplatterMax = 60;
+        this._splatLookup = new Map(); // tile key -> [splatter indices]
+
         // Precalculated values for performance
         this.cosTable = [];
         this.sinTable = [];
@@ -67,6 +72,87 @@ class Renderer {
         }
     }
     
+    addFloorSplatter(worldX, worldY, splatSize) {
+        const splatter = {
+            worldX, worldY,
+            radius: splatSize || 20, // world units
+            // Pre-generate random offsets for sub-splatters
+            blobs: []
+        };
+        // Create 3-6 sub-blobs for irregular shape
+        const blobCount = 3 + Math.floor(Math.random() * 4);
+        for (let i = 0; i < blobCount; i++) {
+            splatter.blobs.push({
+                ox: (Math.random() - 0.5) * splatSize * 0.8,
+                oy: (Math.random() - 0.5) * splatSize * 0.8,
+                r: splatSize * (0.3 + Math.random() * 0.5)
+            });
+        }
+
+        this.floorSplatters.push(splatter);
+
+        // Enforce max count
+        if (this.floorSplatters.length > this.floorSplatterMax) {
+            this.floorSplatters.shift();
+        }
+
+        // Rebuild spatial lookup
+        this._rebuildSplatLookup();
+    }
+
+    _rebuildSplatLookup() {
+        this._splatLookup.clear();
+        for (let i = 0; i < this.floorSplatters.length; i++) {
+            const s = this.floorSplatters[i];
+            const tileSize = this.wallHeight;
+            // Register splatter in all tiles it could touch
+            const minTX = Math.floor((s.worldX - s.radius) / tileSize);
+            const maxTX = Math.floor((s.worldX + s.radius) / tileSize);
+            const minTY = Math.floor((s.worldY - s.radius) / tileSize);
+            const maxTY = Math.floor((s.worldY + s.radius) / tileSize);
+            for (let ty = minTY; ty <= maxTY; ty++) {
+                for (let tx = minTX; tx <= maxTX; tx++) {
+                    const key = ty * 100 + tx; // fast numeric key
+                    let list = this._splatLookup.get(key);
+                    if (!list) {
+                        list = [];
+                        this._splatLookup.set(key, list);
+                    }
+                    list.push(i);
+                }
+            }
+        }
+    }
+
+    clearFloorSplatters() {
+        this.floorSplatters = [];
+        this._splatLookup.clear();
+    }
+
+    // Check if a world position is inside any blood splatter
+    _getSplatIntensity(worldX, worldY, mapX, mapY) {
+        const key = mapY * 100 + mapX;
+        const indices = this._splatLookup.get(key);
+        if (!indices) return 0;
+
+        let maxIntensity = 0;
+        for (const idx of indices) {
+            const s = this.floorSplatters[idx];
+            // Check sub-blobs for irregular shape
+            for (const blob of s.blobs) {
+                const dx = worldX - (s.worldX + blob.ox);
+                const dy = worldY - (s.worldY + blob.oy);
+                const distSq = dx * dx + dy * dy;
+                const rSq = blob.r * blob.r;
+                if (distSq < rSq) {
+                    const intensity = 1 - distSq / rSq;
+                    if (intensity > maxIntensity) maxIntensity = intensity;
+                }
+            }
+        }
+        return maxIntensity;
+    }
+
     buildAcidLookup() {
         // Hazard lookup: 0=none, 1=acid, 2=lava
         this._acidLookup = [];
@@ -486,6 +572,16 @@ class Renderer {
                     let r = Math.min(255, Math.floor(baseR * shade + light.r * 180 * shade));
                     let g = Math.min(255, Math.floor(baseG * shade + light.g * 180 * shade));
                     let b = Math.min(255, Math.floor(baseB * shade + light.b * 180 * shade));
+                    // Blood splatter tinting
+                    if (this._splatLookup.size > 0) {
+                        const si = this._getSplatIntensity(floorWorldX, floorWorldY, mapX, mapY);
+                        if (si > 0) {
+                            const t = si * 0.7;
+                            r = Math.min(255, Math.floor(r * (1 - t) + 140 * shade * t));
+                            g = Math.floor(g * (1 - t) + 10 * shade * t);
+                            b = Math.floor(b * (1 - t) + 5 * shade * t);
+                        }
+                    }
                     this.setPixel(x, y, 0xFF000000 | (b << 16) | (g << 8) | r);
                 }
             }
@@ -546,6 +642,16 @@ class Renderer {
                     let r = Math.min(255, Math.floor(baseR * shade + light.r * 180 * shade));
                     let g = Math.min(255, Math.floor(baseG * shade + light.g * 180 * shade));
                     let b = Math.min(255, Math.floor(baseB * shade + light.b * 180 * shade));
+                    // Blood splatter tinting
+                    if (this._splatLookup.size > 0) {
+                        const si = this._getSplatIntensity(floorWorldX, floorWorldY, mapX, mapY);
+                        if (si > 0) {
+                            const t = si * 0.7;
+                            r = Math.min(255, Math.floor(r * (1 - t) + 140 * shade * t));
+                            g = Math.floor(g * (1 - t) + 10 * shade * t);
+                            b = Math.floor(b * (1 - t) + 5 * shade * t);
+                        }
+                    }
                     this.setPixel(x, y, 0xFF000000 | (b << 16) | (g << 8) | r);
                 }
             }

--- a/js/entities/enemy.js
+++ b/js/entities/enemy.js
@@ -489,6 +489,13 @@ class Enemy {
                 window.game.hud.emitBloodParticles(this.x, this.y, 15);
             }
 
+            // Floor blood splatter
+            if (window.game && window.game.renderer && window.game.renderer.addFloorSplatter) {
+                const splatSizes = { imp: 14, guard: 18, soldier: 16, demon: 30, berserker: 22, spitter: 16, shield_guard: 20, phantom: 12, exploder: 28, sniper: 14, boss: 40 };
+                const splatSize = splatSizes[this.type] || 18;
+                window.game.renderer.addFloorSplatter(this.x, this.y, splatSize);
+            }
+
             // Morale impact: nearby enemies lose morale when ally dies
             if (window.game && window.game.map) {
                 const deathX = this.x;

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -643,8 +643,11 @@ class Player {
             closestEnemy.hitFlashTime = Date.now();
             if (window.game && window.game.hud) {
                 if (isGloryKill) {
-                    // Glory Kill: green flash, large screen shake, crosshair text
+                    // Glory Kill: green flash, large screen shake, crosshair text, extra blood splatter
                     window.game.hud.emitBloodParticles(closestEnemy.x, closestEnemy.y, 15);
+                    if (window.game.renderer && window.game.renderer.addFloorSplatter) {
+                        window.game.renderer.addFloorSplatter(closestEnemy.x, closestEnemy.y, 35);
+                    }
                     window.game.hud.addDamageNumber(closestEnemy.x, closestEnemy.y, damage, true);
                     window.game.hud.triggerScreenShake(10);
                     window.game.hud.showCrosshairText('GLORY KILL!', '#00FF88');

--- a/playtester/tests.js
+++ b/playtester/tests.js
@@ -638,6 +638,7 @@ const TIER_2_TESTS = [
   { id: 'T2-48', name: 'Sprite config and multi-frame animations', fn: T2_48_spriteConfigAnimations }, // issue: #326 #327
   { id: 'T2-49', name: 'Enemy attack telegraph system', fn: T2_49_enemyAttackTelegraph }, // issue: #333
   { id: 'T2-50', name: 'Minimap zone labels and legend', fn: T2_50_minimapZoneLabels }, // issue: #334
+  { id: 'T2-51', name: 'Floor blood splatters on kill', fn: T2_51_floorBloodSplatters }, // issue: #335
 ];
 
 async function T2_08_enemyDamageSystem(page, result) {
@@ -4047,6 +4048,114 @@ async function T2_50_minimapZoneLabels(page, result) {
   } else {
     result.status = 'pass';
     result.note = `Minimap: ${minimapData.zonesWithNames} zones [${minimapData.zoneNames.join(', ')}], legend togglable`;
+  }
+}
+
+async function T2_51_floorBloodSplatters(page, result) {
+  // T2-51: Floor blood splatters on kill (issue: #335)
+  // Pass: renderer has splatter system, splatters created on enemy death, per-type sizes
+  await page.waitForTimeout(1000);
+
+  const splatData = await page.evaluate(() => {
+    if (!window.game || !window.game.renderer) {
+      return { exists: false, reason: 'No game/renderer' };
+    }
+
+    const r = window.game.renderer;
+
+    // Check renderer has splatter system
+    const hasFloorSplatters = Array.isArray(r.floorSplatters);
+    const hasAddMethod = typeof r.addFloorSplatter === 'function';
+    const hasClearMethod = typeof r.clearFloorSplatters === 'function';
+    const hasLookup = r._splatLookup instanceof Map;
+    const hasMax = typeof r.floorSplatterMax === 'number' && r.floorSplatterMax > 0;
+    const hasIntensity = typeof r._getSplatIntensity === 'function';
+
+    // Test adding a splatter
+    const initialCount = r.floorSplatters.length;
+    r.addFloorSplatter(200, 200, 20);
+    const afterAdd = r.floorSplatters.length;
+    const addWorks = afterAdd === initialCount + 1;
+
+    // Check splatter has blobs for irregular shape
+    const lastSplat = r.floorSplatters[r.floorSplatters.length - 1];
+    const hasBlobs = lastSplat && Array.isArray(lastSplat.blobs) && lastSplat.blobs.length >= 3;
+
+    // Check lookup was built
+    const lookupPopulated = r._splatLookup.size > 0;
+
+    // Test intensity function
+    const intensity = r._getSplatIntensity(200, 200, 3, 3);
+    const intensityWorks = intensity > 0;
+
+    // Test clear
+    r.clearFloorSplatters();
+    const clearWorks = r.floorSplatters.length === 0 && r._splatLookup.size === 0;
+
+    // Check enemy death code references addFloorSplatter
+    const enemies = window.game.map ? window.game.map.enemies : [];
+    let deathCodeHasSplatter = false;
+    if (enemies.length > 0) {
+      const src = enemies[0].takeDamage.toString();
+      deathCodeHasSplatter = src.includes('addFloorSplatter');
+    }
+
+    // Check per-type sizes
+    let perTypeSizes = false;
+    if (enemies.length > 0) {
+      const src = enemies[0].takeDamage.toString();
+      perTypeSizes = src.includes('splatSizes');
+    }
+
+    return {
+      exists: true,
+      hasFloorSplatters,
+      hasAddMethod,
+      hasClearMethod,
+      hasLookup,
+      hasMax,
+      hasIntensity,
+      addWorks,
+      hasBlobs,
+      lookupPopulated,
+      intensityWorks,
+      clearWorks,
+      deathCodeHasSplatter,
+      perTypeSizes,
+      maxCount: r.floorSplatterMax
+    };
+  });
+
+  if (!splatData.exists) {
+    result.status = 'fail';
+    result.note = splatData.reason;
+    return;
+  }
+
+  const checks = [
+    ['floorSplatters array', splatData.hasFloorSplatters],
+    ['addFloorSplatter method', splatData.hasAddMethod],
+    ['clearFloorSplatters method', splatData.hasClearMethod],
+    ['spatial lookup map', splatData.hasLookup],
+    ['max splatter limit', splatData.hasMax],
+    ['intensity function', splatData.hasIntensity],
+    ['add creates splatter', splatData.addWorks],
+    ['irregular blob shape', splatData.hasBlobs],
+    ['lookup populated after add', splatData.lookupPopulated],
+    ['intensity > 0 at center', splatData.intensityWorks],
+    ['clear removes all', splatData.clearWorks],
+    ['enemy death creates splatter', splatData.deathCodeHasSplatter],
+    ['per-type splatter sizes', splatData.perTypeSizes]
+  ];
+
+  const failed = checks.filter(([, ok]) => !ok);
+
+  if (failed.length > 0) {
+    result.status = 'fail';
+    result.note = `Missing: ${failed.map(([name]) => name).join(', ')}`;
+  } else {
+    result.status = 'pass';
+    result.note = `Floor splatters: max ${splatData.maxCount}, blob-based, per-type sizes, integrated in floor rendering`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Blood splatters render on the floor where enemies die, integrated into the raycasting floor loop
- Irregular blob-based shapes for natural splatter appearance (3-6 sub-blobs per splatter)
- Per-enemy-type sizes: imp 14, guard 18, demon 30, boss 40 world units
- Glory kills produce extra-large splatters (35 world units)
- Maximum 60 splatters with oldest-first removal for performance
- Splatters clear on level transition and game restart
- Spatial lookup (tile-based Map) for efficient per-pixel checking

## Test plan
- [x] T2-51 verifies splatter array, add/clear methods, spatial lookup
- [x] T2-51 verifies blob-based irregular shapes and intensity function
- [x] T2-51 verifies enemy death code creates splatters with per-type sizes
- [x] All existing tests pass (58 pass, 2 pre-existing flaky, 3 vision skipped)

Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)