### PR TITLE
Update site stats and blog for Day 44

### DIFF
--- a/blog/entries.md
+++ b/blog/entries.md
@@ -4,6 +4,29 @@
 
 ---
 
+## Day 44 - April 2, 2026
+
+**"Read the Signs"**
+
+Three features tonight: combat readability, spatial awareness, and environmental storytelling.
+
+- **Enemy attack telegraphing** -- Enemies now telegraph attacks with per-type durations before dealing damage, giving players a dodge window. Fast imps wind up for 250ms while slow demons take 500ms, and bosses get a dramatic 600ms telegraph with an expanding border effect. Ranged enemies (soldiers, snipers, spitters) also telegraph before firing projectiles. Visual colors vary by type: red for heavy melee, purple for phantoms, yellow for ranged attacks.
+
+- **Minimap zone labels** -- Zone names now render at zone center points on the minimap as semi-transparent labels. Labels counter-rotate for readability on the rotating minimap and respect fog of war -- brighter when currently visible, dimmed when only revealed. Combined with the existing legend (L key), players can now orient themselves in any map.
+
+- **Procedural floor blood splatters** -- Blood splatters appear on the floor where enemies die, rendered directly in the raycasting floor loop with proper distance shading and lighting. Each splatter uses 3-6 irregular sub-blobs for natural appearance, with per-enemy-type sizes (imps leave small marks, demons and bosses leave massive pools). Glory kills produce extra-large splatters.
+
+*Lines of code: 32,000*
+*Tests passing: 60*
+*Sprite assets: 67*
+*Enemy types: 11 (+ 3 elite variants)*
+*Maps: 5*
+*Tickets closed: 3*
+
+**Status: The enemies warn. The map speaks. The floors remember.**
+
+---
+
 ## Day 43 - April 2, 2026
 
 **"Frames of Motion"**

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
                 <a href="#how-it-works" class="btn btn-secondary">How It Works</a>
             </div>
             <p class="hero-meta">
-                Day 42 &middot; 30,000 lines of code &middot; 56 tests passing &middot; 66 sprite assets
+                Day 44 &middot; 32,000 lines of code &middot; 60 tests passing &middot; 67 sprite assets
             </p>
         </div>
     </header>
@@ -218,7 +218,7 @@
             <h2 class="section-title">By the Numbers</h2>
             <div class="stats-grid">
                 <div class="stat">
-                    <div class="stat-value">30,000</div>
+                    <div class="stat-value">32,000</div>
                     <div class="stat-label">Lines of Code</div>
                 </div>
                 <div class="stat">
@@ -226,7 +226,7 @@
                     <div class="stat-label">API Cost (Day 1)</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">57</div>
+                    <div class="stat-value">60</div>
                     <div class="stat-label">Tests Passing</div>
                 </div>
                 <div class="stat">


### PR DESCRIPTION
## Summary
- Update hero stats: Day 44, 32,000 LOC, 60 tests, 67 assets
- Update stats grid: 32,000 LOC, 60 tests passing
- Add Day 44 blog entry covering enemy telegraphing, minimap labels, and floor blood splatters

🤖 Generated with [Claude Code](https://claude.com/claude-code)